### PR TITLE
Add chat memory with LangChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ By default all commands, prompts and responses are logged to a timestamped file 
 
 Set `AUTO_CONFIRM` to `true` in the environment to run safe commands without confirmation. Dangerous commands are always confirmed explicitly.
 
+The assistant now maintains conversational context using LangChain's conversation memory. This allows you to chat naturally and refer back to previous questions in the same session.
+
 ## Running tests
 
 Install the dependencies and run:

--- a/agent/nira_agent.py
+++ b/agent/nira_agent.py
@@ -1,17 +1,51 @@
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_ollama.llms import OllamaLLM
 import json
+from langchain.chains import LLMChain
+from langchain.memory import ConversationBufferMemory
+from langchain.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    MessagesPlaceholder,
+    SystemMessagePromptTemplate,
+)
+from langchain_ollama.llms import OllamaLLM
 
 class NiraAgent:
-    def __init__(self, model_name, base_url) -> None:
-        self.llm = OllamaLLM(
-            model=model_name,
-            base_url=base_url,
-        )
+    """Simple conversational agent backed by LangChain."""
+
+    def __init__(self, model_name=None, base_url=None, llm=None) -> None:
+        """Create a new agent.
+
+        Parameters
+        ----------
+        model_name : str, optional
+            Name of the Ollama model.
+        base_url : str, optional
+            Ollama server URL.
+        llm : BaseLLM, optional
+            Custom LLM instance (used mainly for testing).
+        """
+
+        self.llm = llm or OllamaLLM(model=model_name, base_url=base_url)
 
         config = self.load_config()
         system_prompt = config.get("system", "")
-        self.template = system_prompt + "\nQuestion: {question}\nAnswer:"
+
+        self.prompt = ChatPromptTemplate.from_messages(
+            [
+                SystemMessagePromptTemplate.from_template(system_prompt),
+                MessagesPlaceholder(variable_name="history"),
+                HumanMessagePromptTemplate.from_template("{user_input}"),
+            ]
+        )
+
+        self.memory = ConversationBufferMemory(
+            memory_key="history", input_key="user_input", return_messages=True
+        )
+        self.chain = LLMChain(
+            llm=self.llm,
+            prompt=self.prompt,
+            memory=self.memory,
+        )
 
     def load_config(self):
         try:
@@ -26,7 +60,5 @@ class NiraAgent:
             exit(1)
 
     def ask(self, question: str) -> str:
-        prompt = ChatPromptTemplate.from_template(self.template)
-        msg = prompt.format_messages(question=question)
-
-        return self.llm.invoke(msg)
+        """Ask the agent a question and return the response."""
+        return self.chain.predict(user_input=question)

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ def typewriter(text: str, delay=0.015, prefix="") -> None:
 def main() -> None:
     server, model, auto = parse_env()
 
-    nira = NiraAgent(model, server)
+    nira = NiraAgent(model_name=model, base_url=server)
     console.print("[bold magenta]👾 Nira:[/] Привет! Я готова отвечать на вопросы. Для выхода напиши /exit")
     console.print(f"[dim]Я буду использовать модель: {model}[/]")
     console.rule("[bold blue]Nira Chat[/]")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 langchain
+langchain-community
+langchain-ollama
 ollama
 typer
 rich

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,22 @@
+import unittest
+from agent.nira_agent import NiraAgent
+from langchain_community.llms import FakeListLLM
+
+class ChatMemoryTest(unittest.TestCase):
+    def test_chat_memory_records_messages(self):
+        responses = ["hi there", "i am fine"]
+        llm = FakeListLLM(responses=responses)
+        agent = NiraAgent(llm=llm)
+        first = agent.ask("Hello?")
+        second = agent.ask("How are you?")
+        self.assertEqual(first, "hi there")
+        self.assertEqual(second, "i am fine")
+        msgs = agent.memory.chat_memory.messages
+        self.assertEqual(len(msgs), 4)
+        self.assertEqual(msgs[0].content, "Hello?")
+        self.assertEqual(msgs[1].content, "hi there")
+        self.assertEqual(msgs[2].content, "How are you?")
+        self.assertEqual(msgs[3].content, "i am fine")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- build a conversational agent with `ConversationBufferMemory`
- allow injecting custom LLMs for testing
- mention conversation memory in the README
- require `langchain-community` and `langchain-ollama`
- test that chat memory stores past messages

## Testing
- `python -m unittest discover -s tests -v`