### PR TITLE
Implement dangerous command confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The default server is `http://localhost:11434` and the default model is `qwen3:4
 
 By default all commands, prompts and responses are logged to a timestamped file under the `logs/` directory. You can override the location with the `--log-file` argument.
 
-Set `AUTO_CONFIRM` to `true` in the environment to run safe commands without confirmation. Dangerous commands are always confirmed explicitly.
+Set `AUTO_CONFIRM` to `true` in the environment to run safe commands without confirmation. Any command recognised as dangerous (like `rm -rf` or `shutdown`) will always require explicit confirmation before execution.
 
 The assistant now maintains conversational context using LangChain's conversation memory. This allows you to chat naturally and refer back to previous questions in the same session.
 

--- a/agent/nira_agent.py
+++ b/agent/nira_agent.py
@@ -11,10 +11,11 @@ from langchain_core.prompts import (
 from langchain.agents import create_tool_calling_agent, AgentExecutor
 from agent.tools import tools
 from langchain_ollama import ChatOllama
+from langchain.chains import LLMChain
 
 class NiraAgent:
     def __init__(self, model_name=None, base_url=None, llm=None, log_file="chat.log") -> None:
-        llm = ChatOllama(
+        self.llm = llm or ChatOllama(
             model=model_name,
             base_url=base_url,
             reasoning=False,
@@ -29,27 +30,38 @@ class NiraAgent:
         self.logger.addHandler(handler)
         self.logger.setLevel(logging.INFO)
 
-        memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
+        self.memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
 
         config = self.load_config()
         system_prompt = config.get("system", "You are Nira - an AI assistant.")
 
-        prompt = ChatPromptTemplate.from_messages([
-            SystemMessagePromptTemplate.from_template(system_prompt),
-            MessagesPlaceholder("chat_history"),
-            HumanMessagePromptTemplate.from_template("{input}"),
-            MessagesPlaceholder("agent_scratchpad"),
-        ])
-
-        agent = create_tool_calling_agent(llm=llm, tools=tools, prompt=prompt)
-        self.agent_executor = AgentExecutor(
-            agent=agent,
-            tools=tools,
-            memory=memory,
-            verbose=False,
-            handle_parsing_errors=True,
-            max_iterations=3,
-        )
+        if hasattr(self.llm, "bind_tools"):
+            self.prompt = ChatPromptTemplate.from_messages([
+                SystemMessagePromptTemplate.from_template(system_prompt),
+                MessagesPlaceholder("chat_history"),
+                HumanMessagePromptTemplate.from_template("{input}"),
+                MessagesPlaceholder("agent_scratchpad"),
+            ])
+            agent = create_tool_calling_agent(llm=self.llm, tools=tools, prompt=self.prompt)
+            self.agent_executor = AgentExecutor(
+                agent=agent,
+                tools=tools,
+                memory=self.memory,
+                verbose=False,
+                handle_parsing_errors=True,
+                max_iterations=3,
+            )
+        else:
+            self.prompt = ChatPromptTemplate.from_messages([
+                SystemMessagePromptTemplate.from_template(system_prompt),
+                MessagesPlaceholder("chat_history"),
+                HumanMessagePromptTemplate.from_template("{input}"),
+            ])
+            self.chain = LLMChain(
+                llm=self.llm,
+                prompt=self.prompt,
+                memory=self.memory,
+            )
 
     def log_chat(self, question: str, response: str) -> None:
         """Log a chat interaction to the log file."""
@@ -69,7 +81,10 @@ class NiraAgent:
             exit(1)
 
     def ask(self, question: str) -> str:
-        result = self.agent_executor.invoke({"input": question})
-        response = result.get("output", "") if isinstance(result, dict) else str(result)
+        if hasattr(self, "agent_executor"):
+            result = self.agent_executor.invoke({"input": question})
+            response = result.get("output", "") if isinstance(result, dict) else str(result)
+        else:
+            response = self.chain.predict(input=question)
         self.log_chat(question, response)
         return response

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+from unittest.mock import patch
+from agent.tools.bash_tool import run_bash_command, _is_dangerous
+
+
+class BashToolTest(unittest.TestCase):
+    def test_is_dangerous(self):
+        self.assertTrue(_is_dangerous("rm -rf /"))
+        self.assertFalse(_is_dangerous("ls"))
+
+    @patch("builtins.input", return_value="y")
+    def test_run_safe_command_confirm(self, mock_input):
+        out = run_bash_command("echo hello")
+        self.assertEqual(out.strip(), "hello")
+
+    @patch("builtins.input", return_value="n")
+    def test_cancel_command(self, mock_input):
+        result = run_bash_command("echo hi")
+        self.assertEqual(result, "Команда отменена")
+
+    @patch("subprocess.run")
+    @patch("builtins.input", return_value="y")
+    def test_dangerous_with_auto_confirm(self, mock_input, mock_run):
+        mock_run.return_value.stdout = ""
+        mock_run.return_value.stderr = ""
+        mock_run.return_value.returncode = 0
+        os.environ["AUTO_CONFIRM"] = "true"
+        out = run_bash_command("rm -rf tmp")
+        self.assertEqual(out, "(Пустой вывод)")
+        del os.environ["AUTO_CONFIRM"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add detection of dangerous shell commands
- require confirmation before executing commands
- fall back to simple chain when LLM lacks tool support
- document command confirmation logic
- test dangerous command checks

## Testing
- `pip install -q -r requirements.txt`
- `python -m unittest discover -s tests -v`