### PR TITLE
Handle ctrl+d gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Run the application with:
 python main.py
 ```
 
+Use `/exit`, `Ctrl+C` or `Ctrl+D` to quit the application gracefully.
+
 The default server is `http://localhost:11434` and the default model is `qwen3:4b` if the variables are not set.
 
 By default all commands, prompts and responses are logged to a timestamped file under the `logs/` directory. You can override the location with the `--log-file` argument.

--- a/main.py
+++ b/main.py
@@ -85,6 +85,8 @@ def main() -> None:
             typewriter(response, prefix="👾 Nira: ")
             if speak:
                 voice_synthesizer.speak(response)
+    except EOFError:
+        console.print("\n[bold magenta]👾 Nira:[/] До встречи!")
     except KeyboardInterrupt:
         console.print("\n[bold magenta]👾 Nira:[/] До встречи!")
     except Exception as e:


### PR DESCRIPTION
## Summary
- exit cleanly on EOF (Ctrl+D)
- document exit options in README

## Testing
- `python -m unittest discover tests`