### PR TITLE
Refactor config handling

### DIFF
--- a/agent/nira_agent.py
+++ b/agent/nira_agent.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from logging.handlers import RotatingFileHandler
 from datetime import datetime
@@ -11,6 +10,7 @@ from langchain_core.prompts import (
 )
 from langchain.agents import create_tool_calling_agent, AgentExecutor
 from agent.tools import tools
+from config import load_prompt, ConfigError
 from langchain_ollama import ChatOllama
 from langchain.chains import LLMChain
 
@@ -33,7 +33,11 @@ class NiraAgent:
 
         self.memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
 
-        config = self.load_config()
+        try:
+            config = load_prompt()
+        except ConfigError as exc:
+            print(exc)
+            exit(1)
         system_prompt = config.get("system", "You are Nira - an AI assistant.")
 
         if hasattr(self.llm, "bind_tools"):
@@ -60,18 +64,6 @@ class NiraAgent:
         """Log a chat interaction to the log file."""
         timestamp = datetime.now().isoformat()
         self.logger.info(f"{timestamp}\tQ: {question}\tA: {response}")
-
-    def load_config(self):
-        try:
-            with open("prompt.json", "r") as f:
-                config = json.load(f)
-            return config
-        except FileNotFoundError:
-            print("prompt.json not found. Exiting.")
-            exit(1)
-        except json.JSONDecodeError:
-            print("prompt.json is not valid JSON. Exiting.")
-            exit(1)
 
     def ask(self, question: str) -> str:
         if self.agent_executor is not None:

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,4 @@
+"""Utilities for loading application configuration."""
+from .prompt import load_prompt, ConfigError
+
+__all__ = ["load_prompt", "ConfigError"]

--- a/config/prompt.py
+++ b/config/prompt.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+class ConfigError(Exception):
+    """Raised when there is an issue loading the prompt configuration."""
+
+
+def load_prompt(path: str | Path = Path("prompt.json")) -> dict:
+    """Load the prompt configuration from ``path``.
+
+    Parameters
+    ----------
+    path: str | Path
+        Path to the JSON configuration file. Defaults to ``prompt.json`` in the
+        current working directory.
+
+    Returns
+    -------
+    dict
+        Parsed JSON configuration.
+
+    Raises
+    ------
+    ConfigError
+        If the file does not exist or contains invalid JSON.
+    """
+    path = Path(path)
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError as exc:
+        raise ConfigError(f"{path} not found") from exc
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"{path} is not valid JSON") from exc
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,16 @@
+import unittest
+from config import load_prompt, ConfigError
+
+
+class ConfigLoaderTest(unittest.TestCase):
+    def test_load_prompt_success(self):
+        data = load_prompt("prompt.json")
+        self.assertIn("system", data)
+
+    def test_load_prompt_missing_file(self):
+        with self.assertRaises(ConfigError):
+            load_prompt("missing_file.json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- centralize loading of `prompt.json` in new `config` package
- handle config errors via `ConfigError`
- update `NiraAgent` to use the new loader
- add unit tests for config loader

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6887e89cf0988322a774f7644c69f6a9