### PR TITLE
Fix GitHub tool and formatting

### DIFF
--- a/agent/nira_agent.py
+++ b/agent/nira_agent.py
@@ -4,12 +4,17 @@ from logging.handlers import RotatingFileHandler
 
 from langchain.agents import AgentExecutor, create_tool_calling_agent
 from langchain.memory import ConversationBufferMemory
+
+# fmt: off
+# isort: off
 from langchain_core.prompts import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
     MessagesPlaceholder,
     SystemMessagePromptTemplate,
 )
+# isort: on
+# fmt: on
 from langchain_ollama import ChatOllama
 
 from .prompt import ConfigError, load_prompt

--- a/agent/tools/transcribe_audio_tool.py
+++ b/agent/tools/transcribe_audio_tool.py
@@ -1,12 +1,9 @@
+import importlib
+
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
-try:
-    import importlib
-
-    importlib.import_module("whisper")
-except Exception:
-    whisper = None
+whisper = None
 
 
 class TranscribeAudioInput(BaseModel):
@@ -17,8 +14,12 @@ class TranscribeAudioInput(BaseModel):
 @tool("TranscribeAudio", args_schema=TranscribeAudioInput)
 def transcribe_audio_tool(path: str, model_name: str = "base") -> str:
     """Transcribe speech from an audio file using Whisper if available."""
+    global whisper
     if whisper is None:
-        raise RuntimeError("whisper package not installed")
+        try:
+            whisper = importlib.import_module("whisper")
+        except Exception:
+            raise RuntimeError("whisper package not installed")
     model = whisper.load_model(model_name)
     result = model.transcribe(path)
     return result.get("text", "").strip()

--- a/tests/test_bash_tool.py
+++ b/tests/test_bash_tool.py
@@ -5,7 +5,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from agent.tools.run_bash_command_tool import _is_dangerous, run_bash_command_tool
+# fmt: off
+# isort: off
+from agent.tools.run_bash_command_tool import (
+    _is_dangerous,
+    run_bash_command_tool,
+)
+# isort: on
+# fmt: on
 
 
 class BashToolTest(unittest.TestCase):

--- a/tests/test_github_tool.py
+++ b/tests/test_github_tool.py
@@ -14,7 +14,8 @@ class GitHubToolTest(unittest.TestCase):
             "forks_count": 2,
         }
         result = get_repo_info_tool.func("octocat/Hello-World")
-        self.assertIn("octocat/Hello-World", result)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["full_name"], "octocat/Hello-World")
         mock_get.assert_called_once()
 
     @patch("agent.tools.get_repo_info_tool.requests.get", side_effect=Exception("fail"))

--- a/tests/test_website_tool.py
+++ b/tests/test_website_tool.py
@@ -1,7 +1,14 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from agent.tools.summarize_website_tool import summarize_text, summarize_website_tool
+# fmt: off
+# isort: off
+from agent.tools.summarize_website_tool import (
+    summarize_text,
+    summarize_website_tool,
+)
+# isort: on
+# fmt: on
 
 
 class WebsiteToolTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- return full repo info in `get_repo_info_tool`
- adjust GitHub tool tests for new return value
- keep long imports stable for linters

## Testing
- `black --check .`
- `isort --check .`
- `flake8`
- `pytest -q`