### PR TITLE
Fix youtube tool to support transcript snippet objects

### DIFF
--- a/agent/tools/summarize_youtube_tool.py
+++ b/agent/tools/summarize_youtube_tool.py
@@ -31,7 +31,13 @@ def fetch_captions(video_id: str, languages: list[str] | None = None) -> str:
         parts = api.fetch(video_id, languages=languages)
     except Exception as e:
         return f"Failed to fetch transcript: {e}"
-    text = " ".join(p.get("text", "") for p in parts)
+    text_parts = []
+    for p in parts:
+        if isinstance(p, dict):
+            text_parts.append(p.get("text", ""))
+        else:
+            text_parts.append(getattr(p, "text", ""))
+    text = " ".join(text_parts)
     return text[:MAX_CHARS]
 
 

--- a/tests/test_youtube_tool.py
+++ b/tests/test_youtube_tool.py
@@ -32,6 +32,24 @@ class YouTubeToolTest(unittest.TestCase):
         )
         self.assertEqual(summary, "Hello world.")
 
+    @patch("youtube_transcript_api.YouTubeTranscriptApi.fetch")
+    def test_summarize_youtube_snippets(self, mock_get):
+        from youtube_transcript_api import _transcripts
+
+        snippet1 = _transcripts.FetchedTranscriptSnippet("Hello world.", 0, 1)
+        snippet2 = _transcripts.FetchedTranscriptSnippet(
+            "Second sentence.", 1, 1
+        )
+        fetched = _transcripts.FetchedTranscript(
+            [snippet1, snippet2], "abc123xyz12", "English", "en", True
+        )
+        mock_get.return_value = fetched
+
+        summary = summarize_youtube_tool.func(
+            "https://youtu.be/abc123xyz12", sentences=1
+        )
+        self.assertEqual(summary, "Hello world.")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle `FetchedTranscriptSnippet` objects when reading captions
- add regression test for snippet results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b6fa7b88832297d21ace9764089e