### PR TITLE
Add web search tool

### DIFF
--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -11,6 +11,7 @@ from .summarize_website_tool import summarize_website_tool
 from .summarize_youtube_tool import summarize_youtube_tool
 from .telegram_manager_tool import telegram_manager
 from .transcribe_audio_tool import transcribe_audio_tool
+from .web_search_tool import web_search_tool
 
 # Export a list of tools for use by LangChain agents
 
@@ -26,4 +27,5 @@ tools = [
     get_domain_info_tool,
     summarize_website_tool,
     summarize_youtube_tool,
+    web_search_tool,
 ]

--- a/agent/tools/web_search_tool.py
+++ b/agent/tools/web_search_tool.py
@@ -1,0 +1,28 @@
+from duckduckgo_search import DDGS
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+
+class WebSearchInput(BaseModel):
+    query: str = Field(..., description="Search query")
+    max_results: int = Field(default=5, description="Maximum number of results")
+
+
+@tool("WebSearch", args_schema=WebSearchInput)
+def web_search_tool(query: str, max_results: int = 5) -> str:
+    """Search the web using DuckDuckGo and return top results."""
+    try:
+        with DDGS() as ddgs:
+            results = ddgs.text(query, safesearch="off", max_results=max_results)
+    except Exception as e:
+        return f"Search failed: {e}"
+
+    if not results:
+        return "(No results)"
+
+    lines = []
+    for r in results:
+        title = r.get("title", "No title")
+        url = r.get("href", "")
+        lines.append(f"{title} - {url}".strip())
+    return "\n".join(lines)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ requests
 dnspython
 beautifulsoup4
 youtube-transcript-api
+duckduckgo-search
 
 # Optional voice dependencies are provided in requirements-voice.txt

--- a/tests/test_web_search_tool.py
+++ b/tests/test_web_search_tool.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import patch
+
+from agent.tools.web_search_tool import web_search_tool
+
+
+class WebSearchToolTest(unittest.TestCase):
+    @patch("agent.tools.web_search_tool.DDGS.text")
+    def test_web_search(self, mock_text):
+        mock_text.return_value = [
+            {"title": "Example", "href": "https://example.com", "body": "Test"}
+        ]
+        result = web_search_tool.func("example", max_results=1)
+        self.assertIn("Example", result)
+        self.assertIn("https://example.com", result)
+        mock_text.assert_called_once_with("example", safesearch="off", max_results=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add DuckDuckGo based `WebSearch` tool
- expose the tool through the agent tool list
- include `duckduckgo-search` in requirements
- test the new web search helper

## Testing
- `flake8`
- `black --check .`
- `isort --check .`
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6889543ccec883228b8d45bba311adcb