### PR TITLE
Add Prometheus metrics for tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ By default all commands, prompts and responses are logged to a timestamped file 
 
 Set `AUTO_CONFIRM` to `true` in the environment to run safe commands without confirmation. Any command recognised as dangerous (like `rm -rf` or `shutdown`) will always require explicit confirmation before execution.
 
+Prometheus metrics are exposed on port `8000` by default, providing `tools_called_total` and `tool_error_total` counters. Set the `METRICS_PORT` environment variable to change the port.
+
 
 The assistant now maintains conversational context using LangChain's conversation memory. This allows you to chat naturally and refer back to previous questions in the same session.
 

--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+from functools import wraps
+from prometheus_client import Counter, start_http_server
+
+_METRICS_PORT = int(os.getenv("METRICS_PORT", "8000"))
+
+try:
+    start_http_server(_METRICS_PORT)
+except Exception:
+    pass
+
+# Prometheus counters for tool usage
+TOOLS_CALLED_TOTAL = Counter(
+    "tools_called_total", "Total number of times a tool was called", ["tool"]
+)
+TOOL_ERROR_TOTAL = Counter(
+    "tool_error_total", "Total number of tool errors", ["tool"]
+)
+
+
+def track_tool(fn):
+    """Decorator to track tool usage and errors."""
+    tool_name = getattr(fn, "__name__", "unknown")
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        TOOLS_CALLED_TOTAL.labels(tool=tool_name).inc()
+        try:
+            result = fn(*args, **kwargs)
+            if isinstance(result, str) and result.lower().startswith("error"):
+                TOOL_ERROR_TOTAL.labels(tool=tool_name).inc()
+            return result
+        except Exception:
+            TOOL_ERROR_TOTAL.labels(tool=tool_name).inc()
+            raise
+
+    return wrapper
+
+__all__ = ["track_tool", "TOOLS_CALLED_TOTAL", "TOOL_ERROR_TOTAL"]

--- a/agent/metrics.py
+++ b/agent/metrics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from functools import wraps
+
 from prometheus_client import Counter, start_http_server
 
 _METRICS_PORT = int(os.getenv("METRICS_PORT", "8000"))
@@ -15,9 +16,7 @@ except Exception:
 TOOLS_CALLED_TOTAL = Counter(
     "tools_called_total", "Total number of times a tool was called", ["tool"]
 )
-TOOL_ERROR_TOTAL = Counter(
-    "tool_error_total", "Total number of tool errors", ["tool"]
-)
+TOOL_ERROR_TOTAL = Counter("tool_error_total", "Total number of tool errors", ["tool"])
 
 
 def track_tool(fn):
@@ -37,5 +36,6 @@ def track_tool(fn):
             raise
 
     return wrapper
+
 
 __all__ = ["track_tool", "TOOLS_CALLED_TOTAL", "TOOL_ERROR_TOTAL"]

--- a/agent/tools/check_website_tool.py
+++ b/agent/tools/check_website_tool.py
@@ -1,8 +1,8 @@
 import requests
 from langchain_core.tools import tool
+from pydantic import BaseModel, Field
 
 from ..metrics import track_tool
-from pydantic import BaseModel, Field
 
 
 class CheckWebsiteInput(BaseModel):

--- a/agent/tools/check_website_tool.py
+++ b/agent/tools/check_website_tool.py
@@ -1,5 +1,7 @@
 import requests
 from langchain_core.tools import tool
+
+from ..metrics import track_tool
 from pydantic import BaseModel, Field
 
 
@@ -8,6 +10,7 @@ class CheckWebsiteInput(BaseModel):
 
 
 @tool("CheckWebsite", args_schema=CheckWebsiteInput)
+@track_tool
 def check_website_tool(url: str) -> str:
     """Check if a website is reachable and return HTTP status code."""
     try:

--- a/agent/tools/file_manager_tool.py
+++ b/agent/tools/file_manager_tool.py
@@ -6,7 +6,6 @@ from langchain_core.tools import tool
 from pydantic import BaseModel, Field, NonNegativeInt
 
 from ..metrics import track_tool
-
 from ..status import status_manager
 
 

--- a/agent/tools/file_manager_tool.py
+++ b/agent/tools/file_manager_tool.py
@@ -5,6 +5,8 @@ from typing import List
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field, NonNegativeInt
 
+from ..metrics import track_tool
+
 from ..status import status_manager
 
 
@@ -19,6 +21,7 @@ class FileManagerInput(BaseModel):
 
 
 @tool("FileManager", args_schema=FileManagerInput)
+@track_tool
 def file_manager(
     action: str,
     pattern: str | None = None,

--- a/agent/tools/get_domain_info_tool.py
+++ b/agent/tools/get_domain_info_tool.py
@@ -2,9 +2,8 @@ import dns.resolver
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
-from ..metrics import track_tool
-
 from ..env import get_dns_server
+from ..metrics import track_tool
 
 
 class DomainInfoInput(BaseModel):

--- a/agent/tools/get_domain_info_tool.py
+++ b/agent/tools/get_domain_info_tool.py
@@ -2,6 +2,8 @@ import dns.resolver
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from ..metrics import track_tool
+
 from ..env import get_dns_server
 
 
@@ -10,6 +12,7 @@ class DomainInfoInput(BaseModel):
 
 
 @tool("GetDomainInfo", args_schema=DomainInfoInput)
+@track_tool
 def get_domain_info_tool(domain: str) -> str:
     """Get basic DNS information (A and MX records) for a domain."""
     resolver = dns.resolver.Resolver()

--- a/agent/tools/github_manager_tool.py
+++ b/agent/tools/github_manager_tool.py
@@ -2,6 +2,8 @@ import requests
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from ..metrics import track_tool
+
 from ..env import get_github_token
 from ..status import status_manager
 
@@ -12,6 +14,7 @@ class GitHubManagerInput(BaseModel):
 
 
 @tool("GitHubManager", args_schema=GitHubManagerInput)
+@track_tool
 def github_manager(action: str, repo: str | None = None) -> dict | str:
     """Unified tool for GitHub operations."""
     match action:

--- a/agent/tools/github_manager_tool.py
+++ b/agent/tools/github_manager_tool.py
@@ -2,9 +2,8 @@ import requests
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
-from ..metrics import track_tool
-
 from ..env import get_github_token
+from ..metrics import track_tool
 from ..status import status_manager
 
 

--- a/agent/tools/obsidian_manager_tool.py
+++ b/agent/tools/obsidian_manager_tool.py
@@ -4,9 +4,8 @@ from pathlib import Path
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
-from ..metrics import track_tool
-
 from ..env import get_obsidian_vault
+from ..metrics import track_tool
 from ..status import status_manager
 
 

--- a/agent/tools/obsidian_manager_tool.py
+++ b/agent/tools/obsidian_manager_tool.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from ..metrics import track_tool
+
 from ..env import get_obsidian_vault
 from ..status import status_manager
 
@@ -28,6 +30,7 @@ class ObsidianManagerInput(BaseModel):
 
 
 @tool("ObsidianManager", args_schema=ObsidianManagerInput)
+@track_tool
 def obsidian_manager(
     action: str,
     title: str,

--- a/agent/tools/pdf_manager_tool.py
+++ b/agent/tools/pdf_manager_tool.py
@@ -3,6 +3,8 @@ import re
 
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
+
+from ..metrics import track_tool
 from PyPDF2 import PdfReader
 
 from ..status import status_manager
@@ -24,6 +26,7 @@ class PDFManagerInput(BaseModel):
 
 
 @tool("PDFManager", args_schema=PDFManagerInput)
+@track_tool
 def pdf_manager(
     action: str,
     path: str,

--- a/agent/tools/pdf_manager_tool.py
+++ b/agent/tools/pdf_manager_tool.py
@@ -3,10 +3,9 @@ import re
 
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
-
-from ..metrics import track_tool
 from PyPDF2 import PdfReader
 
+from ..metrics import track_tool
 from ..status import status_manager
 
 MAX_PAGES = 30

--- a/agent/tools/run_bash_command_tool.py
+++ b/agent/tools/run_bash_command_tool.py
@@ -4,9 +4,8 @@ import subprocess
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
-from ..metrics import track_tool
-
 from ..env import get_auto_confirm
+from ..metrics import track_tool
 from ..status import status_manager
 
 

--- a/agent/tools/run_bash_command_tool.py
+++ b/agent/tools/run_bash_command_tool.py
@@ -4,6 +4,8 @@ import subprocess
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from ..metrics import track_tool
+
 from ..env import get_auto_confirm
 from ..status import status_manager
 
@@ -34,6 +36,7 @@ def _confirm(prompt: str) -> bool:
 
 
 @tool("RunBashCommand", args_schema=BashCommandInput)
+@track_tool
 def run_bash_command_tool(command: str) -> str:
     """Execute a system bash command and returns the result."""
     auto_confirm = get_auto_confirm()

--- a/agent/tools/summarize_website_tool.py
+++ b/agent/tools/summarize_website_tool.py
@@ -5,6 +5,8 @@ from bs4 import BeautifulSoup
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from ..metrics import track_tool
+
 MAX_CHARS = 20000
 
 
@@ -35,6 +37,7 @@ class SummarizeWebsiteInput(BaseModel):
 
 
 @tool("SummarizeWebsite", args_schema=SummarizeWebsiteInput)
+@track_tool
 def summarize_website_tool(url: str, sentences: int = 3) -> str:
     """Provide a short summary of the textual content of a website."""
     text = fetch_text_from_url(url)

--- a/agent/tools/summarize_youtube_tool.py
+++ b/agent/tools/summarize_youtube_tool.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 from youtube_transcript_api import YouTubeTranscriptApi
 
 from ..metrics import track_tool
-
 from ..status import status_manager
 
 MAX_CHARS = 20000

--- a/agent/tools/summarize_youtube_tool.py
+++ b/agent/tools/summarize_youtube_tool.py
@@ -5,6 +5,8 @@ from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 from youtube_transcript_api import YouTubeTranscriptApi
 
+from ..metrics import track_tool
+
 from ..status import status_manager
 
 MAX_CHARS = 20000
@@ -54,6 +56,7 @@ class SummarizeYouTubeInput(BaseModel):
 
 
 @tool("SummarizeYouTube", args_schema=SummarizeYouTubeInput)
+@track_tool
 def summarize_youtube_tool(video: str, sentences: int = 3) -> str:
     """Provide a short summary of a YouTube video's auto-generated captions."""
     video_id = extract_video_id(video)

--- a/agent/tools/telegram_manager_tool.py
+++ b/agent/tools/telegram_manager_tool.py
@@ -2,6 +2,8 @@ import requests
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from ..metrics import track_tool
+
 from ..env import get_telegram_bot_token, get_telegram_chat_id
 from ..status import status_manager
 
@@ -12,6 +14,7 @@ class TelegramManagerInput(BaseModel):
 
 
 @tool("TelegramManager", args_schema=TelegramManagerInput)
+@track_tool
 def telegram_manager(action: str, text: str | None = None) -> str:
     """Unified tool for Telegram operations."""
     match action:

--- a/agent/tools/telegram_manager_tool.py
+++ b/agent/tools/telegram_manager_tool.py
@@ -2,9 +2,8 @@ import requests
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
-from ..metrics import track_tool
-
 from ..env import get_telegram_bot_token, get_telegram_chat_id
+from ..metrics import track_tool
 from ..status import status_manager
 
 

--- a/agent/tools/transcribe_audio_tool.py
+++ b/agent/tools/transcribe_audio_tool.py
@@ -3,6 +3,8 @@ import importlib
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from ..metrics import track_tool
+
 whisper = None
 
 
@@ -12,6 +14,7 @@ class TranscribeAudioInput(BaseModel):
 
 
 @tool("TranscribeAudio", args_schema=TranscribeAudioInput)
+@track_tool
 def transcribe_audio_tool(path: str, model_name: str = "base") -> str:
     """Transcribe speech from an audio file using Whisper if available."""
     global whisper

--- a/agent/tools/web_search_tool.py
+++ b/agent/tools/web_search_tool.py
@@ -2,6 +2,8 @@ from ddgs import DDGS
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from ..metrics import track_tool
+
 from ..status import status_manager
 
 
@@ -11,6 +13,7 @@ class WebSearchInput(BaseModel):
 
 
 @tool("WebSearch", args_schema=WebSearchInput)
+@track_tool
 def web_search_tool(query: str, max_results: int = 5) -> str:
     """Search the web using DuckDuckGo and return top results."""
     try:

--- a/agent/tools/web_search_tool.py
+++ b/agent/tools/web_search_tool.py
@@ -3,7 +3,6 @@ from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
 from ..metrics import track_tool
-
 from ..status import status_manager
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,6 @@ dnspython
 beautifulsoup4
 youtube-transcript-api
 ddgs
+prometheus-client
 
 # Optional voice dependencies are provided in requirements-voice.txt


### PR DESCRIPTION
## Summary
- track tool usage with Prometheus counters
- expose metrics server on `METRICS_PORT` (default `8000`)
- document metrics in README
- require `prometheus-client` library

## Testing
- `pip install -q -r requirements.txt`
- `python -m unittest discover -s tests`