### PR TITLE
Improve dangerous command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The default server is `http://localhost:11434` and the default model is `qwen3:4
 
 By default all commands, prompts and responses are logged to a timestamped file under the `logs/` directory. You can override the location with the `--log-file` argument.
 
-Set `AUTO_CONFIRM` to `true` in the environment to run safe commands without confirmation. Any command recognised as dangerous (like `rm -rf` or `shutdown`) will always require explicit confirmation before execution.
+Set `AUTO_CONFIRM` to `true` in the environment to run safe commands without confirmation. Any command recognised as dangerous (like `rm -rf`, `shutdown`, or `poweroff`) will always require explicit confirmation before execution.
 
 Prometheus metrics are exposed on port `8000` by default, providing `tools_called_total` and `tool_error_total` counters. Set the `METRICS_PORT` environment variable to change the port.
 

--- a/agent/tools/run_bash_command_tool.py
+++ b/agent/tools/run_bash_command_tool.py
@@ -19,6 +19,10 @@ _DANGEROUS_PATTERNS = [
     r"\breboot\b",
     r"\bmkfs\b",
     r"\bdd\b.*\/dev\/sd",
+    r"\bpoweroff\b",
+    r"\bhalt\b",
+    r"^init\s+0$",
+    r"\brm\b.*--no-preserve-root",
 ]
 
 
@@ -47,8 +51,9 @@ def run_bash_command_tool(command: str) -> str:
             if dangerous
             else f"Выполнить команду '{command}'? [y/N]: "
         )
-        if not _confirm(prompt):
-            return "Команда отменена"
+        with status_manager.status("ожидаю подтверждения"):
+            if not _confirm(prompt):
+                return "Команда отменена"
 
     try:
         with status_manager.status("выполняю команду"):


### PR DESCRIPTION
## Summary
- show status while awaiting command confirmation
- recognize additional dangerous commands
- document new examples
- test status prompt and new patterns

## Testing
- `pytest -q`