### PR TITLE
Enable markdown rendering in responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Nira
 
 A simple command execution assistant that uses an LLM backend.
+Responses are displayed using Rich's Markdown renderer, allowing formatted output.
 
 ## Installation
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import re
 import sys
-import time
 from getpass import getuser
+
 from rich.markdown import Markdown
 
 from agent.env import get_model, get_server

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import re
 import sys
 import time
 from getpass import getuser
+from rich.markdown import Markdown
 
 from agent.env import get_model, get_server
 from agent.nira_agent import NiraAgent
@@ -29,10 +30,7 @@ def prepare_response(text: str) -> str:
 def typewriter(text: str, delay=0.015, prefix="") -> None:
     if prefix:
         console.print(f"[bold magenta]{prefix}[/]", end="")
-    for char in text:
-        print(char, end="", flush=True)
-        time.sleep(delay)
-    print("\n")
+    console.print(Markdown(text))
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- render assistant output using Rich's Markdown
- note Markdown support in README

## Testing
- `pytest -q`