### PR TITLE
Fix chat memory

### DIFF
--- a/agent/nira_agent.py
+++ b/agent/nira_agent.py
@@ -91,6 +91,8 @@ class NiraAgent:
             response = result["output"] if isinstance(result, dict) else str(result)
         else:
             response = self.llm.predict(question)
+            # Manually persist the interaction when not using an AgentExecutor
+            self.memory.save_context({"input": question}, {"output": response})
 
         self.log_chat(question, response)
         return response


### PR DESCRIPTION
## Summary
- ensure chat context history is stored when not using `AgentExecutor`

## Testing
- `pytest -q`