### PR TITLE
Add status tracking to scrape tool

### DIFF
--- a/agent/tools/scrape_url_tool.py
+++ b/agent/tools/scrape_url_tool.py
@@ -3,13 +3,17 @@ from bs4 import BeautifulSoup
 from langchain_core.tools import tool
 from pydantic import BaseModel, Field
 
+from ..metrics import track_tool
+from ..status import status_manager
+
 MAX_CHARS = 20000
 
 
 def fetch_text_from_url(url: str, max_chars: int = MAX_CHARS) -> str:
     """Fetch plain text content from a website URL."""
     try:
-        resp = requests.get(url, timeout=10)
+        with status_manager.status("читаю страницу"):
+            resp = requests.get(url, timeout=10)
         resp.raise_for_status()
     except Exception as e:
         return f"Failed to fetch page: {e}"
@@ -27,6 +31,7 @@ class ScrapeURLInput(BaseModel):
 
 
 @tool("ScrapeURL", args_schema=ScrapeURLInput)
+@track_tool
 def scrape_url_tool(url: str) -> str:
     """Fetch and return textual content from a website."""
     return fetch_text_from_url(url)

--- a/tests/test_scrape_url_tool.py
+++ b/tests/test_scrape_url_tool.py
@@ -21,8 +21,20 @@ class ScrapeURLToolTest(unittest.TestCase):
         mock_resp.raise_for_status = lambda: None
         mock_get.return_value = mock_resp
 
-        text = scrape_url_tool.func("https://example.com")
+        messages = []
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_status(msg):
+            messages.append(msg)
+            yield
+
+        with patch("agent.tools.scrape_url_tool.status_manager.status", fake_status):
+            text = scrape_url_tool.func("https://example.com")
+
         self.assertIn("First sentence.", text)
+        self.assertIn("читаю страницу", messages[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- display page fetch status when scraping URLs
- track usage of the ScrapeURL tool
- patch status manager in scrape tool tests

## Testing
- `pytest -q`