### PR TITLE
Switch to LLM.invoke and silence PyPDF2 warnings

### DIFF
--- a/agent/nira_agent.py
+++ b/agent/nira_agent.py
@@ -90,7 +90,11 @@ class NiraAgent:
             result = self.agent_executor.invoke({"input": question})
             response = result["output"] if isinstance(result, dict) else str(result)
         else:
-            response = self.llm.predict(question)
+            try:
+                raw = self.llm.invoke(question)
+                response = raw.content if hasattr(raw, "content") else str(raw)
+            except AttributeError:
+                response = self.llm.predict(question)
             self.memory.save_context(
                 {self.memory.input_key: question},
                 {self.memory.output_key: response},

--- a/agent/planner_executor.py
+++ b/agent/planner_executor.py
@@ -48,10 +48,10 @@ class PlannerExecutor:
         )
 
         try:
-            response = self.planner_llm.predict(prompt)
-        except AttributeError:
             raw = self.planner_llm.invoke(prompt)
             response = raw.content if hasattr(raw, "content") else str(raw)
+        except AttributeError:
+            response = self.planner_llm.predict(prompt)
 
         try:
             steps = json.loads(response)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:PyPDF2 is deprecated.*:DeprecationWarning:PyPDF2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import warnings
+
+# Silence deprecation warnings emitted by the PyPDF2 package at import time.
+warnings.filterwarnings(
+    "ignore",
+    message="PyPDF2 is deprecated.*",
+    category=DeprecationWarning,
+    module=r".*PyPDF2.*",
+)


### PR DESCRIPTION
## Summary
- call `llm.invoke` in `NiraAgent.ask`
- switch planner executor to call `invoke`
- filter PyPDF2 deprecation warning in tests
- configure pytest to ignore the PyPDF2 warning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a53cf46bc8322ba632dbc9bf7c02f