### PR TITLE
Use JSON format for chat logs

### DIFF
--- a/agent/nira_agent.py
+++ b/agent/nira_agent.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
@@ -83,7 +84,8 @@ class NiraAgent:
     def log_chat(self, question: str, response: str) -> None:
         """Log a chat interaction to the log file."""
         timestamp = datetime.now().isoformat()
-        self.logger.info(f"{timestamp}\tQ: {question}\tA: {response}")
+        log_entry = {"t": timestamp, "q": question, "a": response}
+        self.logger.info(json.dumps(log_entry, ensure_ascii=False))
 
     def ask(self, question: str) -> str:
         if self.agent_executor is not None:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import json
 from pathlib import Path
 
 from langchain_community.llms import FakeListLLM
@@ -38,10 +39,12 @@ class ChatLoggingTest(unittest.TestCase):
         agent.ask("How are you?")
         lines = log_path.read_text(encoding="utf-8").splitlines()
         self.assertEqual(len(lines), 2)
-        self.assertIn("Hello?", lines[0])
-        self.assertIn("hi there", lines[0])
-        self.assertIn("How are you?", lines[1])
-        self.assertIn("i am fine", lines[1])
+        first = json.loads(lines[0])
+        second = json.loads(lines[1])
+        self.assertEqual(first["q"], "Hello?")
+        self.assertEqual(first["a"], "hi there")
+        self.assertEqual(second["q"], "How are you?")
+        self.assertEqual(second["a"], "i am fine")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log chat entries as JSON
- adjust chat logging test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5d7292fc8322956ac1a66c667113