### PR TITLE
Remove obsolete prepare_response function

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,11 +22,6 @@ voice_synthesizer = None
 USERNAME = getuser().capitalize()
 
 
-def prepare_response(text: str) -> str:
-    response = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
-    return response.strip()
-
-
 def typewriter(text: str, delay=0.015, prefix="") -> None:
     if prefix:
         console.print(f"[bold magenta]{prefix}[/]", end="")


### PR DESCRIPTION
## Summary
- remove `prepare_response` helper
- nothing references it anymore

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad5fe71fc83228658d007a048dd87