### PR TITLE
Remove log file option from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Use `/exit`, `Ctrl+C` or `Ctrl+D` to quit the application gracefully.
 
 The default server is `http://localhost:11434` and the default model is `qwen3:4b` if the variables are not set.
 
-By default all commands, prompts and responses are logged to a timestamped file under the `logs/` directory. You can override the location with the `--log-file` argument.
+By default all commands, prompts and responses are logged to a JSON file named `chat.log` in the current directory.
 
 Set `AUTO_CONFIRM` to `true` in the environment to run safe commands without confirmation. Any command recognised as dangerous (like `rm -rf`, `shutdown`, or `poweroff`) will always require explicit confirmation before execution.
 


### PR DESCRIPTION
## Summary
- remove outdated `--log-file` mention from README
- clarify that logs are written to `chat.log` in the working directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad86c4798832292e9b6087f2d6b6a