### PR TITLE
Ignore __pycache__ folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venv/
 .env
 
 __pycache__/
+**/__pycache__/
 logs/
 tests/__pycache__/
 


### PR DESCRIPTION
## Summary
- ignore all Python bytecode cache folders recursively

## Testing
- `flake8`
- `black --check .`
- `isort --check .`
- `PYTHONPATH=. pytest -q`