### PR TITLE
Improve Whisper model caching

### DIFF
--- a/agent/tools/transcribe_audio_tool.py
+++ b/agent/tools/transcribe_audio_tool.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from ..metrics import track_tool
 
 whisper = None
+whisper_model = None
 
 
 class TranscribeAudioInput(BaseModel):
@@ -17,12 +18,13 @@ class TranscribeAudioInput(BaseModel):
 @track_tool
 def transcribe_audio_tool(path: str, model_name: str = "base") -> str:
     """Transcribe speech from an audio file using Whisper if available."""
-    global whisper
+    global whisper, whisper_model
     if whisper is None:
         try:
             whisper = importlib.import_module("whisper")
         except Exception:
             raise RuntimeError("whisper package not installed")
-    model = whisper.load_model(model_name)
-    result = model.transcribe(path)
+    if whisper_model is None:
+        whisper_model = whisper.load_model(model_name)
+    result = whisper_model.transcribe(path)
     return result.get("text", "").strip()

--- a/agent/voice_recognizer.py
+++ b/agent/voice_recognizer.py
@@ -4,6 +4,8 @@ import numpy as np
 import sounddevice as sd
 import whisper
 
+whisper_model = None
+
 
 def record_audio(duration: int = 5, samplerate: int = 16000):
     """Record audio from the default microphone."""
@@ -18,12 +20,14 @@ def record_audio(duration: int = 5, samplerate: int = 16000):
 
 def transcribe_whisper(duration: int = 5, model_name: str = "base") -> str:
     """Record speech and transcribe it using Whisper."""
+    global whisper_model
     audio, samplerate = record_audio(duration, samplerate=16000)
     with tempfile.NamedTemporaryFile(suffix=".wav") as f:
         import soundfile as sf
 
         sf.write(f.name, audio, samplerate)
-        model = whisper.load_model(model_name)
-        result = model.transcribe(f.name)
+        if whisper_model is None:
+            whisper_model = whisper.load_model(model_name)
+        result = whisper_model.transcribe(f.name)
         text = result["text"]
     return text.strip()

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -15,6 +15,9 @@ class FileToolsTest(unittest.TestCase):
         mock_whisper = mock.Mock()
         mock_whisper.load_model.return_value.transcribe.return_value = {"text": "hi"}
         mock_import.return_value = mock_whisper
+        # Ensure cache is clear
+        transcribe_audio_tool.func.whisper = None
+        transcribe_audio_tool.func.whisper_model = None
         result = transcribe_audio_tool.func("file.wav", model_name="base")
         self.assertEqual(result, "hi")
 


### PR DESCRIPTION
## Summary
- cache the Whisper model in `voice_recognizer` for reuse across calls
- cache the Whisper model in `transcribe_audio_tool`
- adjust audio transcription test for cache reset

## Testing
- `PYTHONPATH=. python -m unittest discover -s tests -p 'test_*.py' -v`