### PR TITLE
Refactor env getters to use helper

### DIFF
--- a/agent/env.py
+++ b/agent/env.py
@@ -9,49 +9,54 @@ load_dotenv()
 _TRUE_VALUES = {"1", "true", "yes", "y"}
 
 
+def _get_env(name: str, default: str = "") -> str:
+    """Return the value of *name* from the environment."""
+    return os.getenv(name, default)
+
+
 def get_server(default: str = "http://localhost:11434") -> str:
     """Return the server URL from the environment."""
-    return os.getenv("SERVER", default)
+    return _get_env("SERVER", default)
 
 
 def get_model(default: str = "qwen3:4b") -> str:
     """Return the model name from the environment."""
-    return os.getenv("MODEL", default)
+    return _get_env("MODEL", default)
 
 
 def get_auto_confirm() -> bool:
     """Return True if AUTO_CONFIRM is truthy in the environment."""
-    return os.getenv("AUTO_CONFIRM", "").lower() in _TRUE_VALUES
+    return _get_env("AUTO_CONFIRM").lower() in _TRUE_VALUES
 
 
 def get_telegram_bot_token() -> str:
     """Return the Telegram bot token from the environment."""
-    return os.getenv("TELEGRAM_BOT_TOKEN", "")
+    return _get_env("TELEGRAM_BOT_TOKEN")
 
 
 def get_telegram_chat_id() -> str:
     """Return the Telegram chat ID from the environment."""
-    return os.getenv("TELEGRAM_CHAT_ID", "")
+    return _get_env("TELEGRAM_CHAT_ID")
 
 
 def get_github_token() -> str:
     """Return the GitHub access token from the environment."""
-    return os.getenv("GITHUB_TOKEN", "")
+    return _get_env("GITHUB_TOKEN")
 
 
 def get_todoist_token() -> str:
     """Return the Todoist API token from the environment."""
-    return os.getenv("TODOIST_TOKEN", "")
+    return _get_env("TODOIST_TOKEN")
 
 
 def get_obsidian_vault() -> str:
     """Return the path to the Obsidian vault."""
-    return os.getenv("OBSIDIAN_VAULT", "")
+    return _get_env("OBSIDIAN_VAULT")
 
 
 def get_dns_server() -> str:
     """Return the DNS server to use for lookups if specified."""
-    return os.getenv("DNS_SERVER", "")
+    return _get_env("DNS_SERVER")
 
 
 def parse_env() -> tuple[str, str, bool]:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import patch
+
+from agent import env
+
+
+class EnvGetterTest(unittest.TestCase):
+    def test_get_server_default(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(env.get_server("http://local"), "http://local")
+
+    def test_get_auto_confirm_true(self):
+        with patch.dict("os.environ", {"AUTO_CONFIRM": "yes"}):
+            self.assertTrue(env.get_auto_confirm())
+
+    def test_get_auto_confirm_false(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(env.get_auto_confirm())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `_get_env` helper in `agent.env`
- refactor all getter functions to use the helper
- add unit tests for `get_server` and `get_auto_confirm`

## Testing
- `PYTHONPATH=. pytest -q`