### PR TITLE
Optimize regex usage in bash command tool

### DIFF
--- a/agent/tools/run_bash_command_tool.py
+++ b/agent/tools/run_bash_command_tool.py
@@ -25,10 +25,14 @@ _DANGEROUS_PATTERNS = [
     r"\brm\b.*--no-preserve-root",
 ]
 
+# Compile regexes once at module import for efficiency
+_DANGEROUS_REGEXES = [re.compile(pat) for pat in _DANGEROUS_PATTERNS]
+
 
 def _is_dangerous(command: str) -> bool:
-    for pat in _DANGEROUS_PATTERNS:
-        if re.search(pat, command):
+    """Return True if command matches any dangerous pattern."""
+    for regex in _DANGEROUS_REGEXES:
+        if regex.search(command):
             return True
     return False
 


### PR DESCRIPTION
## Summary
- compile dangerous command regexes once
- update `_is_dangerous` to search compiled patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ade649f3083228848f9b2ab12cdb1