### PR TITLE
Add specialized agent routing

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,8 +1,8 @@
 from .base_agent import BaseAgent
 from .coder_agent import CoderAgent
+from .nira_agent import NiraAgent
 from .researcher_agent import ResearcherAgent
 from .sysops_agent import SysOpsAgent
-from .nira_agent import NiraAgent
 
 __all__ = [
     "BaseAgent",

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,13 @@
+from .base_agent import BaseAgent
+from .coder_agent import CoderAgent
+from .researcher_agent import ResearcherAgent
+from .sysops_agent import SysOpsAgent
+from .nira_agent import NiraAgent
+
+__all__ = [
+    "BaseAgent",
+    "CoderAgent",
+    "ResearcherAgent",
+    "SysOpsAgent",
+    "NiraAgent",
+]

--- a/agent/base_agent.py
+++ b/agent/base_agent.py
@@ -1,0 +1,114 @@
+import json
+import logging
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
+
+from langchain.agents import AgentExecutor, create_tool_calling_agent
+from langchain_ollama import ChatOllama
+
+# fmt: off
+# isort: off
+from langchain_core.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    MessagesPlaceholder,
+    SystemMessagePromptTemplate,
+)
+# isort: on
+# fmt: on
+
+from .nira_memory import NiraMemory
+from .prompt import ConfigError, load_prompt
+from .tools import tools as default_tools
+
+
+class BaseAgent:
+    def __init__(
+        self,
+        model_name=None,
+        base_url=None,
+        llm=None,
+        log_file="chat.log",
+        *,
+        system_prompt: str | None = None,
+        tool_list: list | None = None,
+        max_iterations=15,
+        max_bytes=1 * 1024 * 1024,
+        backup_count=5,
+    ) -> None:
+        self.llm = llm or ChatOllama(
+            model=model_name,
+            base_url=base_url,
+            reasoning=False,
+            # temperature=0.3,
+        )
+
+        self.max_iterations = max_iterations
+
+        self.logger = logging.getLogger(self.__class__.__name__)
+        for h in list(self.logger.handlers):
+            self.logger.removeHandler(h)
+        handler = RotatingFileHandler(
+            log_file, maxBytes=max_bytes, backupCount=backup_count
+        )
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        self.logger.addHandler(handler)
+        self.logger.setLevel(logging.INFO)
+
+        self.memory = NiraMemory(memory_key="chat_history", return_messages=True)
+
+        try:
+            config = load_prompt()
+        except ConfigError:
+            raise
+        system_prompt = system_prompt or config.get(
+            "system", "You are Nira - an AI assistant."
+        )
+
+        tools = tool_list or default_tools
+
+        if hasattr(self.llm, "bind_tools"):
+            self.prompt = ChatPromptTemplate.from_messages(
+                [
+                    SystemMessagePromptTemplate.from_template(system_prompt),
+                    MessagesPlaceholder("chat_history"),
+                    HumanMessagePromptTemplate.from_template("{input}"),
+                    MessagesPlaceholder("agent_scratchpad"),
+                ]
+            )
+
+            agent = create_tool_calling_agent(self.llm, tools, self.prompt)
+            self.agent_executor = AgentExecutor(
+                agent=agent,
+                tools=tools,
+                memory=self.memory,
+                verbose=False,
+                handle_parsing_errors=True,
+                max_iterations=max_iterations,
+            )
+        else:
+            self.agent_executor = None
+
+    def log_chat(self, question: str, response: str) -> None:
+        """Log a chat interaction to the log file."""
+        timestamp = datetime.now().isoformat()
+        log_entry = {"t": timestamp, "q": question, "a": response}
+        self.logger.info(json.dumps(log_entry, ensure_ascii=False))
+
+    def ask(self, question: str) -> str:
+        if self.agent_executor is not None:
+            result = self.agent_executor.invoke({"input": question})
+            response = result["output"] if isinstance(result, dict) else str(result)
+        else:
+            try:
+                raw = self.llm.invoke(question)
+                response = raw.content if hasattr(raw, "content") else str(raw)
+            except AttributeError:
+                response = self.llm.predict(question)
+            self.memory.save_context(
+                {self.memory.input_key: question},
+                {self.memory.output_key: response},
+            )
+
+        self.log_chat(question, response)
+        return response

--- a/agent/coder_agent.py
+++ b/agent/coder_agent.py
@@ -1,7 +1,6 @@
 from .base_agent import BaseAgent
-from .tools.run_bash_command_tool import run_bash_command_tool
 from .tools.github_manager_tool import github_manager
-
+from .tools.run_bash_command_tool import run_bash_command_tool
 
 CODER_SYSTEM = "You are a coding assistant helping with programming tasks."
 CODER_TOOLS = [run_bash_command_tool, github_manager]

--- a/agent/coder_agent.py
+++ b/agent/coder_agent.py
@@ -1,0 +1,12 @@
+from .base_agent import BaseAgent
+from .tools.run_bash_command_tool import run_bash_command_tool
+from .tools.github_manager_tool import github_manager
+
+
+CODER_SYSTEM = "You are a coding assistant helping with programming tasks."
+CODER_TOOLS = [run_bash_command_tool, github_manager]
+
+
+class CoderAgent(BaseAgent):
+    def __init__(self, **kwargs):
+        super().__init__(system_prompt=CODER_SYSTEM, tool_list=CODER_TOOLS, **kwargs)

--- a/agent/nira_agent.py
+++ b/agent/nira_agent.py
@@ -1,47 +1,40 @@
-import json
 import logging
-from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
-from langchain.agents import AgentExecutor, create_tool_calling_agent
 from langchain_ollama import ChatOllama
 
-# fmt: off
-# isort: off
-from langchain_core.prompts import (
-    ChatPromptTemplate,
-    HumanMessagePromptTemplate,
-    MessagesPlaceholder,
-    SystemMessagePromptTemplate,
-)
-# isort: on
-# fmt: on
-
-from .nira_memory import NiraMemory
-from .prompt import ConfigError, load_prompt
-from .tools import tools
+from .coder_agent import CoderAgent
+from .researcher_agent import ResearcherAgent
+from .sysops_agent import SysOpsAgent
+from .env import get_model, get_server
 
 
 class NiraAgent:
+    """Route tasks to specialized agents using an LLM classifier."""
+
     def __init__(
         self,
-        model_name=None,
-        base_url=None,
-        llm=None,
-        log_file="chat.log",
+        classifier_llm: ChatOllama | None = None,
+        coder: CoderAgent | None = None,
+        researcher: ResearcherAgent | None = None,
+        sysops: SysOpsAgent | None = None,
+        model_name: str | None = None,
+        base_url: str | None = None,
         *,
-        max_iterations=15,
-        max_bytes=1 * 1024 * 1024,
-        backup_count=5,
+        log_file: str = "chat.log",
+        max_bytes: int = 1 * 1024 * 1024,
+        backup_count: int = 5,
     ) -> None:
-        self.llm = llm or ChatOllama(
-            model=model_name,
-            base_url=base_url,
+        model = model_name or get_model()
+        server = base_url or get_server()
+        self.classifier_llm = classifier_llm or ChatOllama(
+            model=model,
+            base_url=server,
             reasoning=False,
-            # temperature=0.3,
         )
-
-        self.max_iterations = max_iterations
+        self.coder = coder or CoderAgent(model_name=model, base_url=server)
+        self.researcher = researcher or ResearcherAgent(model_name=model, base_url=server)
+        self.sysops = sysops or SysOpsAgent(model_name=model, base_url=server)
 
         self.logger = logging.getLogger(self.__class__.__name__)
         for h in list(self.logger.handlers):
@@ -53,56 +46,26 @@ class NiraAgent:
         self.logger.addHandler(handler)
         self.logger.setLevel(logging.INFO)
 
-        self.memory = NiraMemory(memory_key="chat_history", return_messages=True)
-
+    def _classify(self, task: str) -> str:
+        prompt = (
+            "Classify the user request into one of: coder, researcher, sysops. "
+            "Respond with only the label.\nRequest: " + task
+        )
         try:
-            config = load_prompt()
-        except ConfigError:
-            raise
-        system_prompt = config.get("system", "You are Nira - an AI assistant.")
-
-        if hasattr(self.llm, "bind_tools"):
-            self.prompt = ChatPromptTemplate.from_messages(
-                [
-                    SystemMessagePromptTemplate.from_template(system_prompt),
-                    MessagesPlaceholder("chat_history"),
-                    HumanMessagePromptTemplate.from_template("{input}"),
-                    MessagesPlaceholder("agent_scratchpad"),
-                ]
-            )
-
-            agent = create_tool_calling_agent(self.llm, tools, self.prompt)
-            self.agent_executor = AgentExecutor(
-                agent=agent,
-                tools=tools,
-                memory=self.memory,
-                verbose=False,
-                handle_parsing_errors=True,
-                max_iterations=max_iterations,
-            )
-        else:
-            self.agent_executor = None
-
-    def log_chat(self, question: str, response: str) -> None:
-        """Log a chat interaction to the log file."""
-        timestamp = datetime.now().isoformat()
-        log_entry = {"t": timestamp, "q": question, "a": response}
-        self.logger.info(json.dumps(log_entry, ensure_ascii=False))
+            raw = self.classifier_llm.invoke(prompt)
+            label = raw.content if hasattr(raw, "content") else str(raw)
+        except AttributeError:
+            label = self.classifier_llm.predict(prompt)
+        return label.strip().lower()
 
     def ask(self, question: str) -> str:
-        if self.agent_executor is not None:
-            result = self.agent_executor.invoke({"input": question})
-            response = result["output"] if isinstance(result, dict) else str(result)
+        label = self._classify(question)
+        if label.startswith("coder"):
+            agent = self.coder
+        elif label.startswith("sysops"):
+            agent = self.sysops
         else:
-            try:
-                raw = self.llm.invoke(question)
-                response = raw.content if hasattr(raw, "content") else str(raw)
-            except AttributeError:
-                response = self.llm.predict(question)
-            self.memory.save_context(
-                {self.memory.input_key: question},
-                {self.memory.output_key: response},
-            )
-
-        self.log_chat(question, response)
+            agent = self.researcher
+        response = agent.ask(question)
+        self.logger.info(response)
         return response

--- a/agent/nira_agent.py
+++ b/agent/nira_agent.py
@@ -4,9 +4,9 @@ from logging.handlers import RotatingFileHandler
 from langchain_ollama import ChatOllama
 
 from .coder_agent import CoderAgent
+from .env import get_model, get_server
 from .researcher_agent import ResearcherAgent
 from .sysops_agent import SysOpsAgent
-from .env import get_model, get_server
 
 
 class NiraAgent:
@@ -33,7 +33,9 @@ class NiraAgent:
             reasoning=False,
         )
         self.coder = coder or CoderAgent(model_name=model, base_url=server)
-        self.researcher = researcher or ResearcherAgent(model_name=model, base_url=server)
+        self.researcher = researcher or ResearcherAgent(
+            model_name=model, base_url=server
+        )
         self.sysops = sysops or SysOpsAgent(model_name=model, base_url=server)
 
         self.logger = logging.getLogger(self.__class__.__name__)

--- a/agent/researcher_agent.py
+++ b/agent/researcher_agent.py
@@ -1,8 +1,7 @@
 from .base_agent import BaseAgent
-from .tools.web_search_tool import web_search_tool
 from .tools.summarise_text_tool import summarise_text_tool
 from .tools.summarize_youtube_tool import summarize_youtube_tool
-
+from .tools.web_search_tool import web_search_tool
 
 RESEARCHER_SYSTEM = "You research information and summarise findings."
 RESEARCHER_TOOLS = [web_search_tool, summarise_text_tool, summarize_youtube_tool]
@@ -10,4 +9,6 @@ RESEARCHER_TOOLS = [web_search_tool, summarise_text_tool, summarize_youtube_tool
 
 class ResearcherAgent(BaseAgent):
     def __init__(self, **kwargs):
-        super().__init__(system_prompt=RESEARCHER_SYSTEM, tool_list=RESEARCHER_TOOLS, **kwargs)
+        super().__init__(
+            system_prompt=RESEARCHER_SYSTEM, tool_list=RESEARCHER_TOOLS, **kwargs
+        )

--- a/agent/researcher_agent.py
+++ b/agent/researcher_agent.py
@@ -1,0 +1,13 @@
+from .base_agent import BaseAgent
+from .tools.web_search_tool import web_search_tool
+from .tools.summarise_text_tool import summarise_text_tool
+from .tools.summarize_youtube_tool import summarize_youtube_tool
+
+
+RESEARCHER_SYSTEM = "You research information and summarise findings."
+RESEARCHER_TOOLS = [web_search_tool, summarise_text_tool, summarize_youtube_tool]
+
+
+class ResearcherAgent(BaseAgent):
+    def __init__(self, **kwargs):
+        super().__init__(system_prompt=RESEARCHER_SYSTEM, tool_list=RESEARCHER_TOOLS, **kwargs)

--- a/agent/sysops_agent.py
+++ b/agent/sysops_agent.py
@@ -2,7 +2,6 @@ from .base_agent import BaseAgent
 from .tools.check_website_tool import check_website_tool
 from .tools.run_bash_command_tool import run_bash_command_tool
 
-
 SYSOPS_SYSTEM = "You perform system administration and operational tasks."
 SYSOPS_TOOLS = [run_bash_command_tool, check_website_tool]
 

--- a/agent/sysops_agent.py
+++ b/agent/sysops_agent.py
@@ -1,0 +1,12 @@
+from .base_agent import BaseAgent
+from .tools.check_website_tool import check_website_tool
+from .tools.run_bash_command_tool import run_bash_command_tool
+
+
+SYSOPS_SYSTEM = "You perform system administration and operational tasks."
+SYSOPS_TOOLS = [run_bash_command_tool, check_website_tool]
+
+
+class SysOpsAgent(BaseAgent):
+    def __init__(self, **kwargs):
+        super().__init__(system_prompt=SYSOPS_SYSTEM, tool_list=SYSOPS_TOOLS, **kwargs)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,18 +2,18 @@ import unittest
 
 from langchain_community.llms import FakeListLLM
 
-from agent.nira_agent import NiraAgent
+from agent.base_agent import BaseAgent
 
 
 class AgentConfigTest(unittest.TestCase):
     def test_default_max_iterations(self):
         llm = FakeListLLM(responses=["hi"])
-        agent = NiraAgent(llm=llm)
+        agent = BaseAgent(llm=llm)
         self.assertEqual(agent.max_iterations, 15)
 
     def test_custom_max_iterations(self):
         llm = FakeListLLM(responses=["hi"])
-        agent = NiraAgent(llm=llm, max_iterations=7)
+        agent = BaseAgent(llm=llm, max_iterations=7)
         self.assertEqual(agent.max_iterations, 7)
 
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -4,14 +4,14 @@ from pathlib import Path
 
 from langchain_community.llms import FakeListLLM
 
-from agent.nira_agent import NiraAgent
+from agent.base_agent import BaseAgent
 
 
 class ChatMemoryTest(unittest.TestCase):
     def test_chat_memory_records_messages(self):
         responses = ["hi there", "i am fine"]
         llm = FakeListLLM(responses=responses)
-        agent = NiraAgent(llm=llm)
+        agent = BaseAgent(llm=llm)
         first = agent.ask("Hello?")
         second = agent.ask("How are you?")
         self.assertEqual(first, "hi there")
@@ -31,7 +31,7 @@ class ChatLoggingTest(unittest.TestCase):
         log_path = Path("chat.log")
         if log_path.exists():
             log_path.unlink()
-        agent = NiraAgent(llm=llm, log_file=str(log_path))
+        agent = BaseAgent(llm=llm, log_file=str(log_path))
         agent.ask("Hello?")
         agent.ask("How are you?")
         lines = log_path.read_text(encoding="utf-8").splitlines()

--- a/tests/test_planner_executor.py
+++ b/tests/test_planner_executor.py
@@ -3,6 +3,7 @@ import unittest
 from langchain_community.llms import FakeListLLM
 
 from agent.nira_agent import NiraAgent
+from agent.coder_agent import CoderAgent
 from agent.planner_executor import PlannerExecutor
 
 
@@ -10,7 +11,9 @@ class PlannerExecutorTest(unittest.TestCase):
     def test_planner_executor_sequence(self):
         planner_llm = FakeListLLM(responses=['["one","two"]', "[]"])
         executor_llm = FakeListLLM(responses=["res1", "res2"])
-        executor = NiraAgent(llm=executor_llm)
+        classifier_llm = FakeListLLM(responses=["coder", "coder"])
+        coder = CoderAgent(llm=executor_llm)
+        executor = NiraAgent(classifier_llm=classifier_llm, coder=coder)
         pe = PlannerExecutor(planner_llm=planner_llm, executor=executor)
         final = pe.run("do stuff")
         self.assertEqual(final, "res2")

--- a/tests/test_planner_executor.py
+++ b/tests/test_planner_executor.py
@@ -2,8 +2,8 @@ import unittest
 
 from langchain_community.llms import FakeListLLM
 
-from agent.nira_agent import NiraAgent
 from agent.coder_agent import CoderAgent
+from agent.nira_agent import NiraAgent
 from agent.planner_executor import PlannerExecutor
 
 

--- a/tests/test_routing_agent.py
+++ b/tests/test_routing_agent.py
@@ -1,8 +1,9 @@
 import unittest
+
 from langchain_community.llms import FakeListLLM
 
-from agent.nira_agent import NiraAgent
 from agent.coder_agent import CoderAgent
+from agent.nira_agent import NiraAgent
 from agent.researcher_agent import ResearcherAgent
 from agent.sysops_agent import SysOpsAgent
 

--- a/tests/test_routing_agent.py
+++ b/tests/test_routing_agent.py
@@ -1,0 +1,30 @@
+import unittest
+from langchain_community.llms import FakeListLLM
+
+from agent.nira_agent import NiraAgent
+from agent.coder_agent import CoderAgent
+from agent.researcher_agent import ResearcherAgent
+from agent.sysops_agent import SysOpsAgent
+
+
+class RoutingAgentTest(unittest.TestCase):
+    def test_routing_to_specialists(self):
+        classifier_llm = FakeListLLM(responses=["coder", "researcher", "sysops"])
+        coder_llm = FakeListLLM(responses=["code-result"])
+        researcher_llm = FakeListLLM(responses=["research-result"])
+        sysops_llm = FakeListLLM(responses=["sysops-result"])
+
+        agent = NiraAgent(
+            classifier_llm=classifier_llm,
+            coder=CoderAgent(llm=coder_llm),
+            researcher=ResearcherAgent(llm=researcher_llm),
+            sysops=SysOpsAgent(llm=sysops_llm),
+        )
+
+        self.assertEqual(agent.ask("task1"), "code-result")
+        self.assertEqual(agent.ask("task2"), "research-result")
+        self.assertEqual(agent.ask("task3"), "sysops-result")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create `BaseAgent` as common agent implementation
- implement `CoderAgent`, `ResearcherAgent`, and `SysOpsAgent` with different prompts and tool lists
- repurpose `NiraAgent` as router that delegates to specialized agents
- update planner tests and add routing test
- adjust existing tests to use `BaseAgent`

## Testing
- `python -m unittest discover -s tests`