### PR TITLE
Add Gradio chat interface

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1,0 +1,26 @@
+import gradio as gr
+from agent.agents.planner_executor import PlannerExecutor
+
+planner = PlannerExecutor()
+
+
+def chat(user_message: str, history: list[tuple[str, str]]):
+    response = planner.run(user_message)
+    history = history + [(user_message, response)]
+    return "", history
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("# Nira Chat")
+    chatbot = gr.Chatbot()
+    with gr.Row():
+        msg = gr.Textbox(label="Message", scale=4)
+        submit = gr.Button("Submit", scale=1)
+    clear = gr.Button("Clear")
+
+    submit.click(chat, [msg, chatbot], [msg, chatbot])
+    msg.submit(chat, [msg, chatbot], [msg, chatbot])
+    clear.click(lambda: [], None, chatbot, queue=False)
+
+
+demo.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ddgs
 prometheus-client
 
 # Optional voice dependencies are provided in requirements-voice.txt
+gradio


### PR DESCRIPTION
## Summary
- add a simple Gradio front-end for chatting with `PlannerExecutor`
- include gradio as a requirement

## Testing
- `flake8`
- `pytest -k test_planner_executor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688b2c5dc218832297291d5c34582395