### PR TITLE
Refactor voice modules

### DIFF
--- a/agent/core/voice_recognizer.py
+++ b/agent/core/voice_recognizer.py
@@ -2,6 +2,7 @@ import tempfile
 
 import numpy as np
 
+from .status import status_manager
 from .whisper_utils import transcribe_file
 
 try:  # Optional dependency
@@ -17,11 +18,14 @@ def record_audio(duration: int = 5, samplerate: int = 16000):
             "sounddevice is not installed. Install voice requirements to enable recording."
         )
 
-    print("🎤 Говорите...")
-    audio = sd.rec(
-        int(duration * samplerate), samplerate=samplerate, channels=1, dtype="float32"
-    )
-    sd.wait()
+    with status_manager.status("🎤 Говорите..."):
+        audio = sd.rec(
+            int(duration * samplerate),
+            samplerate=samplerate,
+            channels=1,
+            dtype="float32",
+        )
+        sd.wait()
     audio = np.squeeze(audio)
     return audio, samplerate
 

--- a/agent/core/voice_synthesizer.py
+++ b/agent/core/voice_synthesizer.py
@@ -17,8 +17,6 @@ try:
 except Exception:  # pragma: no cover - executed only when missing
     TTS = None
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
-
 
 class VoiceSynthesizer:
     def __init__(self, model="tts_models/en/ljspeech/tacotron2-DDC") -> None:
@@ -31,6 +29,7 @@ class VoiceSynthesizer:
                 "sounddevice and soundfile are required for voice playback."
             )
 
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.tts = TTS(model)
 
     def speak(self, text: str):
@@ -40,7 +39,7 @@ class VoiceSynthesizer:
             )
 
         Path("output").mkdir(exist_ok=True)
-        self.tts.tts_to_file(text, file_path="output/output.wav", device=device)
+        self.tts.tts_to_file(text, file_path="output/output.wav", device=self.device)
         data, sample_rate = soundfile.read("output/output.wav")
         sounddevice.play(data, sample_rate)
         sounddevice.wait()

--- a/tests/test_voice_modules.py
+++ b/tests/test_voice_modules.py
@@ -41,6 +41,80 @@ class VoiceModuleDepsTest(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 vs.VoiceSynthesizer()
 
+    def test_record_audio_status(self):
+        import types
+        from contextlib import contextmanager
+
+        import numpy as np
+
+        dummy_sd = types.SimpleNamespace()
+
+        def rec(frames, samplerate=16000, channels=1, dtype="float32"):
+            return np.zeros((frames, channels), dtype=np.float32)
+
+        dummy_sd.rec = rec
+        dummy_sd.wait = lambda: None
+
+        messages = []
+
+        @contextmanager
+        def fake_status(msg):
+            messages.append(msg)
+            yield
+
+        with patch.dict("sys.modules", {"sounddevice": dummy_sd}):
+            import agent.core.voice_recognizer as vr
+
+            importlib.reload(vr)
+            with patch(
+                "agent.core.voice_recognizer.status_manager.status", fake_status
+            ):
+                audio, sr = vr.record_audio(duration=1, samplerate=16000)
+
+        self.assertEqual(sr, 16000)
+        self.assertEqual(audio.shape, (16000,))
+        self.assertIn("Говорите", messages[0])
+
+    def test_voice_synthesizer_device_runtime_check(self):
+        import types
+
+        class FakeCuda:
+            def __init__(self) -> None:
+                self._available = False
+
+            def is_available(self):
+                return self._available
+
+        fake_cuda = FakeCuda()
+
+        class FakeTorch:
+            cuda = fake_cuda
+
+        class DummyTTS:
+            def __init__(self, model):
+                self.model = model
+
+        dummy_sd = types.SimpleNamespace()
+        dummy_sf = types.SimpleNamespace()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "torch": FakeTorch(),
+                "TTS": types.SimpleNamespace(api=types.SimpleNamespace(TTS=DummyTTS)),
+                "TTS.api": types.SimpleNamespace(TTS=DummyTTS),
+                "sounddevice": dummy_sd,
+                "soundfile": dummy_sf,
+            },
+        ):
+            import agent.core.voice_synthesizer as vs
+
+            importlib.reload(vs)
+            vs.torch.cuda.is_available = lambda: True
+            synth = vs.VoiceSynthesizer()
+
+        self.assertEqual(synth.device, "cuda")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- use `status_manager` when prompting for speech recording
- move device detection to VoiceSynthesizer initialization
- test status message during audio recording
- test runtime CUDA device selection

## Testing
- `flake8`
- `black --check .`
- `isort --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b3d66cf888322b1f5fe4ab1ff44df