### PR TITLE
Refactor planner to delegate execution

### DIFF
--- a/agent/agents/base_agent.py
+++ b/agent/agents/base_agent.py
@@ -59,6 +59,7 @@ class BaseAgent:
         )
 
         tools = tool_list or default_tools
+        self.tool_list = tools
 
         if hasattr(self.llm, "bind_tools"):
             self.prompt = ChatPromptTemplate.from_messages(

--- a/agent/agents/coder_agent.py
+++ b/agent/agents/coder_agent.py
@@ -8,6 +8,7 @@ CODER_TOOLS = [run_bash_command_tool, github_manager]
 
 class CoderAgent(BaseAgent):
     tool_list = CODER_TOOLS
+
     def __init__(self, **kwargs):
         config = load_prompt()
         super().__init__(

--- a/agent/agents/coder_agent.py
+++ b/agent/agents/coder_agent.py
@@ -7,10 +7,11 @@ CODER_TOOLS = [run_bash_command_tool, github_manager]
 
 
 class CoderAgent(BaseAgent):
+    tool_list = CODER_TOOLS
     def __init__(self, **kwargs):
         config = load_prompt()
         super().__init__(
             system_prompt=config.get("coder_system"),
-            tool_list=CODER_TOOLS,
+            tool_list=self.tool_list,
             **kwargs,
         )

--- a/agent/agents/planner_executor.py
+++ b/agent/agents/planner_executor.py
@@ -15,7 +15,7 @@ class PlannerExecutor:
     def __init__(
         self,
         planner_llm: ChatOllama | None = None,
-        executor: RouterAgent | None = None,
+        *,
         config: NiraConfig | None = None,
     ) -> None:
         cfg = config or load_config()
@@ -24,7 +24,7 @@ class PlannerExecutor:
         self.planner_llm = planner_llm or ChatOllama(
             model=model, base_url=server, reasoning=False, temperature=0.3
         )
-        self.executor = executor or RouterAgent(model_name=model, base_url=server)
+        self.config = cfg
         self.graph = self._build_graph()
 
     def _build_graph(self) -> StateGraph:
@@ -85,7 +85,10 @@ class PlannerExecutor:
 
     def _execute_node(self, state: Dict[str, Any]) -> Dict[str, Any]:
         step = state["steps"][state["index"]]
-        result = self.executor.ask(step)
+        router = RouterAgent(
+            model_name=self.config.model, base_url=self.config.server
+        )
+        result = router.ask(step)
         return {
             "goal": state["goal"],
             "steps": state["steps"],

--- a/agent/agents/planner_executor.py
+++ b/agent/agents/planner_executor.py
@@ -85,9 +85,7 @@ class PlannerExecutor:
 
     def _execute_node(self, state: Dict[str, Any]) -> Dict[str, Any]:
         step = state["steps"][state["index"]]
-        router = RouterAgent(
-            model_name=self.config.model, base_url=self.config.server
-        )
+        router = RouterAgent(model_name=self.config.model, base_url=self.config.server)
         result = router.ask(step)
         return {
             "goal": state["goal"],

--- a/agent/agents/researcher_agent.py
+++ b/agent/agents/researcher_agent.py
@@ -8,10 +8,11 @@ RESEARCHER_TOOLS = [web_search_tool, summarise_text_tool, summarize_youtube_tool
 
 
 class ResearcherAgent(BaseAgent):
+    tool_list = RESEARCHER_TOOLS
     def __init__(self, **kwargs):
         config = load_prompt()
         super().__init__(
             system_prompt=config.get("researcher_system"),
-            tool_list=RESEARCHER_TOOLS,
+            tool_list=self.tool_list,
             **kwargs,
         )

--- a/agent/agents/researcher_agent.py
+++ b/agent/agents/researcher_agent.py
@@ -9,6 +9,7 @@ RESEARCHER_TOOLS = [web_search_tool, summarise_text_tool, summarize_youtube_tool
 
 class ResearcherAgent(BaseAgent):
     tool_list = RESEARCHER_TOOLS
+
     def __init__(self, **kwargs):
         config = load_prompt()
         super().__init__(

--- a/agent/agents/sysops_agent.py
+++ b/agent/agents/sysops_agent.py
@@ -8,6 +8,7 @@ SYSOPS_TOOLS = [run_bash_command_tool, check_website_tool]
 
 class SysOpsAgent(BaseAgent):
     tool_list = SYSOPS_TOOLS
+
     def __init__(self, **kwargs):
         config = load_prompt()
         super().__init__(

--- a/agent/agents/sysops_agent.py
+++ b/agent/agents/sysops_agent.py
@@ -7,10 +7,11 @@ SYSOPS_TOOLS = [run_bash_command_tool, check_website_tool]
 
 
 class SysOpsAgent(BaseAgent):
+    tool_list = SYSOPS_TOOLS
     def __init__(self, **kwargs):
         config = load_prompt()
         super().__init__(
             system_prompt=config.get("sysops_system"),
-            tool_list=SYSOPS_TOOLS,
+            tool_list=self.tool_list,
             **kwargs,
         )

--- a/tests/test_planner_executor.py
+++ b/tests/test_planner_executor.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 from langchain_community.llms import FakeListLLM
 
 from agent.agents.coder_agent import CoderAgent
-from agent.agents.researcher_agent import ResearcherAgent
 from agent.agents.planner_executor import PlannerExecutor
+from agent.agents.researcher_agent import ResearcherAgent
 from agent.agents.router_agent import RouterAgent
 from agent.agents.sysops_agent import SysOpsAgent
 

--- a/tests/test_planner_executor.py
+++ b/tests/test_planner_executor.py
@@ -1,22 +1,36 @@
 import unittest
+from unittest.mock import patch
 
 from langchain_community.llms import FakeListLLM
 
 from agent.agents.coder_agent import CoderAgent
+from agent.agents.researcher_agent import ResearcherAgent
 from agent.agents.planner_executor import PlannerExecutor
 from agent.agents.router_agent import RouterAgent
+from agent.agents.sysops_agent import SysOpsAgent
 
 
 class PlannerExecutorTest(unittest.TestCase):
-    def test_planner_executor_sequence(self):
-        planner_llm = FakeListLLM(responses=['["one","two"]', "[]"])
-        executor_llm = FakeListLLM(responses=["res1", "res2"])
-        classifier_llm = FakeListLLM(responses=["coder", "coder"])
-        coder = CoderAgent(llm=executor_llm)
-        executor = RouterAgent(classifier_llm=classifier_llm, coder=coder)
-        pe = PlannerExecutor(planner_llm=planner_llm, executor=executor)
-        final = pe.run("do stuff")
-        self.assertEqual(final, "res2")
+    def test_planner_delegates_to_router(self):
+        planner_llm = FakeListLLM(responses=['["c","r","s"]', "[]"])
+
+        classifier_llm = FakeListLLM(responses=["coder", "researcher", "sysops"])
+        coder_llm = FakeListLLM(responses=["code-res"])
+        researcher_llm = FakeListLLM(responses=["research-res"])
+        sysops_llm = FakeListLLM(responses=["sysops-res"])
+
+        router = RouterAgent(
+            classifier_llm=classifier_llm,
+            coder=CoderAgent(llm=coder_llm),
+            researcher=ResearcherAgent(llm=researcher_llm),
+            sysops=SysOpsAgent(llm=sysops_llm),
+        )
+
+        with patch("agent.agents.planner_executor.RouterAgent", return_value=router):
+            pe = PlannerExecutor(planner_llm=planner_llm)
+            final = pe.run("do stuff")
+
+        self.assertEqual(final, "sysops-res")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `PlannerExecutor` instantiate `RouterAgent` when executing
- expose tools on specialized agents through a `tool_list` attribute
- update integration tests for new planner/agent interaction

## Testing
- `pytest -q`