### PR TITLE
Add pre-commit lint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,13 @@ Thank you for your interest in improving **Nira**. Please follow the guidelines 
 ```bash
 pip install -r requirements.txt
 pip install -r requirements-dev.txt  # for linting and formatting
+pre-commit install  # sets up git hooks
 ```
 
 ## Coding standards
 
-Run the linters and formatters before submitting a pull request:
+Run the linters and formatters before submitting a pull request. They are also
+executed automatically on staged files via the installed pre-commit hook:
 
 ```bash
 flake8

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Install the development dependencies:
 
 ```bash
 pip install -r requirements-dev.txt
+pre-commit install  # sets up git hooks to run black and isort automatically
 ```
 
 Run the linters and formatters:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8
 black
 isort
+pre-commit


### PR DESCRIPTION
## Summary
- use pre-commit to run black and isort before each commit
- document git hook setup in README and CONTRIBUTING
- add `pre-commit` to development requirements

## Testing
- `python -m unittest discover -s tests -p 'test_*.py' -v | tail -n 5`
- `flake8 .`
- `black --check .`
- `isort --check .`


------
https://chatgpt.com/codex/tasks/task_e_688b4b79c0408322817c0ed86d7032bd