### PR TITLE
Use consistent 'summarize' naming

### DIFF
--- a/agent/agents/researcher_agent.py
+++ b/agent/agents/researcher_agent.py
@@ -1,10 +1,10 @@
 from ..core.prompt import load_prompt
-from ..tools.researcher.summarise_text_tool import summarise_text_tool
+from ..tools.researcher.summarize_text_tool import summarize_text_tool
 from ..tools.researcher.summarize_youtube_tool import summarize_youtube_tool
 from ..tools.researcher.web_search_tool import web_search_tool
 from .base_agent import BaseAgent
 
-RESEARCHER_TOOLS = [web_search_tool, summarise_text_tool, summarize_youtube_tool]
+RESEARCHER_TOOLS = [web_search_tool, summarize_text_tool, summarize_youtube_tool]
 
 
 class ResearcherAgent(BaseAgent):

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -7,7 +7,7 @@ from .homeassistant_manager_tool import homeassistant_manager
 from .obsidian_manager_tool import obsidian_manager
 from .pdf_manager_tool import pdf_manager
 from .proxmox_manager_tool import proxmox_manager
-from .researcher.summarise_text_tool import summarise_text_tool
+from .researcher.summarize_text_tool import summarize_text_tool
 from .researcher.summarize_youtube_tool import summarize_youtube_tool
 from .researcher.web_search_tool import web_search_tool
 from .scrape_url_tool import scrape_url_tool
@@ -33,7 +33,7 @@ tools = [
     get_domain_info_tool,
     proxmox_manager,
     scrape_url_tool,
-    summarise_text_tool,
+    summarize_text_tool,
     summarize_youtube_tool,
     web_search_tool,
 ]

--- a/agent/tools/obsidian_manager_tool.py
+++ b/agent/tools/obsidian_manager_tool.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from ..core.config import load_config
 from ..core.metrics import track_tool
 from ..core.status import status_manager
-from .researcher.summarise_text_tool import summarise_text_tool
+from .researcher.summarize_text_tool import summarize_text_tool
 
 
 def _vault_path() -> Path:
@@ -52,6 +52,6 @@ def obsidian_manager(
                     text = path.read_text(encoding="utf-8")
             except Exception as e:
                 return f"Failed to read note: {e}"
-            return summarise_text_tool.func(text=text, sentences=sentences)
+            return summarize_text_tool.func(text=text, sentences=sentences)
         case _:
             return f"Error: unknown action '{action}'"

--- a/agent/tools/pdf_manager_tool.py
+++ b/agent/tools/pdf_manager_tool.py
@@ -7,7 +7,7 @@ from PyPDF2 import PdfReader
 from ..core.constants import MAX_PDF_CHARS
 from ..core.metrics import track_tool
 from ..core.status import status_manager
-from .researcher.summarise_text_tool import summarise_text_tool
+from .researcher.summarize_text_tool import summarize_text_tool
 
 
 class PDFManagerInput(BaseModel):
@@ -41,6 +41,6 @@ def pdf_manager(
         case "extract_text":
             return joined
         case "summarize":
-            return summarise_text_tool.func(text=joined, sentences=sentences)
+            return summarize_text_tool.func(text=joined, sentences=sentences)
         case _:
             return f"Error: unknown action '{action}'"

--- a/agent/tools/researcher/summarize_text_tool.py
+++ b/agent/tools/researcher/summarize_text_tool.py
@@ -6,14 +6,14 @@ from pydantic import BaseModel, Field
 from ...core.metrics import track_tool
 
 
-class SummariseTextInput(BaseModel):
-    text: str = Field(..., description="Text to summarise")
+class SummarizeTextInput(BaseModel):
+    text: str = Field(..., description="Text to summarize")
     sentences: int = Field(default=3, description="Number of sentences")
 
 
-@tool("SummariseText", args_schema=SummariseTextInput)
+@tool("SummarizeText", args_schema=SummarizeTextInput)
 @track_tool
-def summarise_text_tool(text: str, sentences: int = 3) -> str:
+def summarize_text_tool(text: str, sentences: int = 3) -> str:
     """Return a short summary of the provided text."""
     parts = re.split(r"(?<=[.!?])\s+", text)
     return " ".join(parts[:sentences]).strip()

--- a/agent/tools/researcher/summarize_youtube_tool.py
+++ b/agent/tools/researcher/summarize_youtube_tool.py
@@ -8,7 +8,7 @@ from youtube_transcript_api import YouTubeTranscriptApi
 from ...core.constants import MAX_TEXT_CHARS
 from ...core.metrics import track_tool
 from ...core.status import status_manager
-from .summarise_text_tool import summarise_text_tool
+from .summarize_text_tool import summarize_text_tool
 
 
 def extract_video_id(url_or_id: str) -> str:
@@ -60,4 +60,4 @@ def summarize_youtube_tool(video: str, sentences: int = 3) -> str:
         text = fetch_captions(video_id)
     if text.startswith("Failed to fetch"):
         return text
-    return summarise_text_tool.func(text=text, sentences=sentences)
+    return summarize_text_tool.func(text=text, sentences=sentences)

--- a/tests/test_pdf_tools.py
+++ b/tests/test_pdf_tools.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from agent.tools.file_manager_tool import file_manager
 from agent.tools.pdf_manager_tool import pdf_manager
-from agent.tools.researcher.summarise_text_tool import summarise_text_tool
+from agent.tools.researcher.summarize_text_tool import summarize_text_tool
 
 
 class PDFToolsTest(unittest.TestCase):
@@ -13,7 +13,7 @@ class PDFToolsTest(unittest.TestCase):
         self.assertIn("Hello world", text)
 
     def test_summarize_text(self):
-        summary = summarise_text_tool.func(text="One. Two. Three. Four.", sentences=2)
+        summary = summarize_text_tool.func(text="One. Two. Three. Four.", sentences=2)
         self.assertEqual(summary, "One. Two.")
 
     def test_summarize_pdf(self):

--- a/tests/test_scrape_url_tool.py
+++ b/tests/test_scrape_url_tool.py
@@ -4,14 +4,14 @@ from unittest.mock import MagicMock, patch
 # fmt: off
 # isort: off
 from agent.tools.scrape_url_tool import scrape_url_tool
-from agent.tools.researcher.summarise_text_tool import summarise_text_tool
+from agent.tools.researcher.summarize_text_tool import summarize_text_tool
 # isort: on
 # fmt: on
 
 
 class ScrapeURLToolTest(unittest.TestCase):
     def test_summarize_text(self):
-        summary = summarise_text_tool.func(text="One. Two. Three.", sentences=2)
+        summary = summarize_text_tool.func(text="One. Two. Three.", sentences=2)
         self.assertEqual(summary, "One. Two.")
 
     @patch("agent.tools.scrape_url_tool.requests.get")

--- a/tests/test_youtube_tool.py
+++ b/tests/test_youtube_tool.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 # fmt: off
 # isort: off
-from agent.tools.researcher.summarise_text_tool import summarise_text_tool
+from agent.tools.researcher.summarize_text_tool import summarize_text_tool
 from agent.tools.researcher.summarize_youtube_tool import (
     extract_video_id,
     summarize_youtube_tool,
@@ -18,7 +18,7 @@ class YouTubeToolTest(unittest.TestCase):
         self.assertEqual(vid, "abc123xyz12")
 
     def test_summarize_text(self):
-        summary = summarise_text_tool.func(text="One. Two. Three.", sentences=2)
+        summary = summarize_text_tool.func(text="One. Two. Three.", sentences=2)
         self.assertEqual(summary, "One. Two.")
 
     @patch("youtube_transcript_api.YouTubeTranscriptApi.fetch")


### PR DESCRIPTION
## Summary
- rename `summarise_text_tool.py` to `summarize_text_tool.py`
- update imports in agents, tools, and tests
- rename internal classes and functions to `summarize`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b59c67c288322adfd283a0f4d69e5