### PR TITLE
Add caching to load_prompt

### DIFF
--- a/agent/core/prompt.py
+++ b/agent/core/prompt.py
@@ -1,4 +1,5 @@
 import json
+from functools import lru_cache
 from pathlib import Path
 
 
@@ -6,6 +7,7 @@ class ConfigError(Exception):
     """Raised when there is an issue loading the prompt configuration."""
 
 
+@lru_cache(maxsize=1)
 def load_prompt(path: str | Path = Path("prompt.json")) -> dict:
     """Load the prompt configuration from ``path``.
 
@@ -33,3 +35,6 @@ def load_prompt(path: str | Path = Path("prompt.json")) -> dict:
         raise ConfigError(f"{path} not found") from exc
     except json.JSONDecodeError as exc:
         raise ConfigError(f"{path} is not valid JSON") from exc
+
+
+__all__ = ["ConfigError", "load_prompt"]

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,9 +1,16 @@
+import io
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
 from agent.core.prompt import ConfigError, load_prompt
 
 
 class TestConfigLoader:
+    def setup_method(self):
+        load_prompt.cache_clear()
+
     def test_load_prompt_success(self):
         data = load_prompt("prompt.json")
         assert "system" in data
@@ -16,3 +23,11 @@ class TestConfigLoader:
     def test_load_prompt_missing_file(self):
         with pytest.raises(ConfigError):
             load_prompt("missing_file.json")
+
+    def test_load_prompt_cached(self):
+        path = Path("prompt.json")
+        with patch("io.open", wraps=io.open) as mock_open:
+            first = load_prompt(path)
+            second = load_prompt(path)
+        assert first is second
+        mock_open.assert_called_once()


### PR DESCRIPTION
## Summary
- cache `load_prompt` using `lru_cache` like `load_config`
- expose cache clearing via `load_prompt.cache_clear`
- test prompt caching by mocking file open

## Testing
- `pre-commit run --files agent/core/prompt.py tests/test_prompt.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c540779448322b25fb5159a254292