### PR TITLE
Fix conversation memory persistence with planner and router

### DIFF
--- a/agent/agents/base_agent.py
+++ b/agent/agents/base_agent.py
@@ -28,6 +28,7 @@ class BaseAgent:
         base_url=None,
         llm=None,
         log_file="chat.json",
+        memory: NiraMemory | None = None,
         *,
         system_prompt: str | None = None,
         tool_list: list | None = None,
@@ -49,7 +50,9 @@ class BaseAgent:
             self.__class__.__name__, log_file, max_bytes, backup_count
         )
 
-        self.memory = NiraMemory(memory_key="chat_history", return_messages=True)
+        self.memory = memory or NiraMemory(
+            memory_key="chat_history", return_messages=True
+        )
 
         try:
             config = load_prompt()

--- a/agent/agents/coder_agent.py
+++ b/agent/agents/coder_agent.py
@@ -1,4 +1,5 @@
 from ..core.prompt import load_prompt
+from ..core.nira_memory import NiraMemory
 from ..tools.coder.github_manager_tool import github_manager
 from ..tools.sysops.run_bash_command_tool import run_bash_command_tool
 from .base_agent import BaseAgent
@@ -9,10 +10,11 @@ CODER_TOOLS = [run_bash_command_tool, github_manager]
 class CoderAgent(BaseAgent):
     tool_list = CODER_TOOLS
 
-    def __init__(self, **kwargs):
+    def __init__(self, memory: NiraMemory | None = None, **kwargs):
         config = load_prompt()
         super().__init__(
             system_prompt=config.get("coder_system"),
             tool_list=self.tool_list,
+            memory=memory,
             **kwargs,
         )

--- a/agent/agents/researcher_agent.py
+++ b/agent/agents/researcher_agent.py
@@ -1,4 +1,5 @@
 from ..core.prompt import load_prompt
+from ..core.nira_memory import NiraMemory
 from ..tools.researcher.summarize_text_tool import summarize_text_tool
 from ..tools.researcher.summarize_youtube_tool import summarize_youtube_tool
 from ..tools.researcher.web_search_tool import web_search_tool
@@ -10,10 +11,11 @@ RESEARCHER_TOOLS = [web_search_tool, summarize_text_tool, summarize_youtube_tool
 class ResearcherAgent(BaseAgent):
     tool_list = RESEARCHER_TOOLS
 
-    def __init__(self, **kwargs):
+    def __init__(self, memory: NiraMemory | None = None, **kwargs):
         config = load_prompt()
         super().__init__(
             system_prompt=config.get("researcher_system"),
             tool_list=self.tool_list,
+            memory=memory,
             **kwargs,
         )

--- a/agent/agents/router_agent.py
+++ b/agent/agents/router_agent.py
@@ -2,6 +2,7 @@ from langchain_ollama import ChatOllama
 
 from ..core.config import NiraConfig, load_config
 from ..core.logger_utils import setup_logger
+from ..core.nira_memory import NiraMemory
 from ..core.prompt import load_prompt
 from .base_agent import BaseAgent
 from .coder_agent import CoderAgent
@@ -18,6 +19,7 @@ class RouterAgent:
         coder: CoderAgent | None = None,
         researcher: ResearcherAgent | None = None,
         sysops: SysOpsAgent | None = None,
+        memory: NiraMemory | None = None,
         model_name: str | None = None,
         base_url: str | None = None,
         config: NiraConfig | None = None,
@@ -34,11 +36,18 @@ class RouterAgent:
             base_url=server,
             reasoning=False,
         )
-        self.coder = coder or CoderAgent(model_name=model, base_url=server)
-        self.researcher = researcher or ResearcherAgent(
-            model_name=model, base_url=server
+        self.memory = memory or NiraMemory(
+            memory_key="chat_history", return_messages=True
         )
-        self.sysops = sysops or SysOpsAgent(model_name=model, base_url=server)
+        self.coder = coder or CoderAgent(
+            model_name=model, base_url=server, memory=self.memory
+        )
+        self.researcher = researcher or ResearcherAgent(
+            model_name=model, base_url=server, memory=self.memory
+        )
+        self.sysops = sysops or SysOpsAgent(
+            model_name=model, base_url=server, memory=self.memory
+        )
 
         self.logger = setup_logger(
             self.__class__.__name__, log_file, max_bytes, backup_count

--- a/agent/agents/sysops_agent.py
+++ b/agent/agents/sysops_agent.py
@@ -1,4 +1,5 @@
 from ..core.prompt import load_prompt
+from ..core.nira_memory import NiraMemory
 from ..tools.sysops.check_website_tool import check_website_tool
 from ..tools.sysops.run_bash_command_tool import run_bash_command_tool
 from .base_agent import BaseAgent
@@ -9,10 +10,11 @@ SYSOPS_TOOLS = [run_bash_command_tool, check_website_tool]
 class SysOpsAgent(BaseAgent):
     tool_list = SYSOPS_TOOLS
 
-    def __init__(self, **kwargs):
+    def __init__(self, memory: NiraMemory | None = None, **kwargs):
         config = load_prompt()
         super().__init__(
             system_prompt=config.get("sysops_system"),
             tool_list=self.tool_list,
+            memory=memory,
             **kwargs,
         )


### PR DESCRIPTION
## Summary
- inject optional memory into `BaseAgent`
- share memory between agents via `RouterAgent`
- keep a single `RouterAgent` instance in `PlannerExecutor`
- allow specialist agents to accept external memory

## Testing
- `pytest -q`