### PR TITLE
Integrate persistent memory into agent memory

### DIFF
--- a/tests/test_nira_memory.py
+++ b/tests/test_nira_memory.py
@@ -1,0 +1,15 @@
+from agent.core.nira_memory import NiraMemory
+from agent.core.persistent_memory import PersistentMemory
+
+
+def test_loads_persistent_memory(tmp_path):
+    db_path = tmp_path / "memory.db"
+    store = PersistentMemory(db_path)
+    store.set("name", "Alice")
+
+    memory = NiraMemory(persistent_memory=PersistentMemory(db_path))
+    loaded = memory.load_memory_variables({})
+
+    assert memory.persistent_memory_key in loaded
+    assert loaded[memory.persistent_memory_key]["name"] == "Alice"
+    assert memory.memory_variables == [memory.memory_key, memory.persistent_memory_key]


### PR DESCRIPTION
## Summary
- Include SQLite-backed `PersistentMemory` alongside in-memory chat history for agent context
- Add unit test verifying persistent data is loaded with agent memory

## Testing
- `pre-commit run --files agent/core/nira_memory.py tests/test_nira_memory.py`
- `pytest`