### PR TITLE
Handle missing Obsidian vault path

### DIFF
--- a/agent/tools/obsidian_manager_tool.py
+++ b/agent/tools/obsidian_manager_tool.py
@@ -34,7 +34,10 @@ def obsidian_manager(
     """Unified tool for Obsidian vault operations."""
     match action:
         case "create_note":
-            path = _vault_path() / f"{title}.md"
+            try:
+                path = _vault_path() / f"{title}.md"
+            except RuntimeError as e:
+                return f"Error: {e}"
             if path.exists():
                 return f"Note already exists: {path}"
             try:
@@ -44,7 +47,10 @@ def obsidian_manager(
             except Exception as e:
                 return f"Failed to create note: {e}"
         case "summarize_note":
-            path = _vault_path() / f"{title}.md"
+            try:
+                path = _vault_path() / f"{title}.md"
+            except RuntimeError as e:
+                return f"Error: {e}"
             if not path.is_file():
                 return f"(File not found: {path})"
             try:

--- a/tests/test_obsidian_tools.py
+++ b/tests/test_obsidian_tools.py
@@ -2,8 +2,6 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
-import pytest
-
 from agent.core.config import load_config
 from agent.tools.obsidian_manager_tool import obsidian_manager
 
@@ -30,5 +28,5 @@ class TestObsidianTools:
 
     def test_missing_vault(self):
         with mock.patch.dict("os.environ", {}, clear=True):
-            with pytest.raises(RuntimeError):
-                obsidian_manager.func("create_note", title="Foo")
+            result = obsidian_manager.func("create_note", title="Foo")
+            assert result == "Error: OBSIDIAN_VAULT not configured"


### PR DESCRIPTION
## Summary
- handle missing OBSIDIAN_VAULT by catching RuntimeError and returning an error string
- adjust Obsidian tests for new error handling

## Testing
- `pre-commit run --files agent/tools/obsidian_manager_tool.py tests/test_obsidian_tools.py`
- `pytest`