### PR TITLE
Handle unknown router labels with warning

### DIFF
--- a/agent/agents/router_agent.py
+++ b/agent/agents/router_agent.py
@@ -1,3 +1,5 @@
+import warnings
+
 from langchain_ollama import ChatOllama
 
 from ..core.config import NiraConfig, load_config
@@ -64,9 +66,15 @@ class RouterAgent:
         label = self._classify(question)
         if label.startswith("coder"):
             agent: BaseAgent = self.coder
+        elif label.startswith("researcher"):
+            agent = self.researcher
         elif label.startswith("sysops"):
             agent = self.sysops
         else:
+            warnings.warn(
+                f"Unknown agent label '{label}', defaulting to ResearcherAgent",
+                stacklevel=1,
+            )
             agent = self.researcher
         response = agent.ask(question)
         return response


### PR DESCRIPTION
## Summary
- warn and default to ResearcherAgent when router classification returns unknown labels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eafd7f3fc8322a878581a650853f0