### PR TITLE
Add natural language memory workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ logs/
 
 llm_data
 chat.json
+memory.db

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Prometheus metrics are exposed on port `8000` by default, providing `tools_calle
 The assistant now maintains conversational context using LangChain's conversation memory. This allows you to chat naturally and refer back to previous questions in the same session.
 
 A simple SQLite-backed store provides long-term memory for key/value data such as user information or facts. The ``MemoryManager`` tool lets agents read or update this database, which defaults to ``memory.db``.
-You can also ask Nira to remember facts directly: say ``remember <key> is <value>`` and it will be stored in the database. Later, asking something like ``what is <key>?`` will retrieve the saved value before any other tools are used.
+You can also ask Nira to remember facts directly in natural language: ``please remember my favourite colour is blue`` will store it, and later ``what is my favourite colour?`` will retrieve the saved value before any other tools are used.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Prometheus metrics are exposed on port `8000` by default, providing `tools_calle
 The assistant now maintains conversational context using LangChain's conversation memory. This allows you to chat naturally and refer back to previous questions in the same session.
 
 A simple SQLite-backed store provides long-term memory for key/value data such as user information or facts. The ``MemoryManager`` tool lets agents read or update this database, which defaults to ``memory.db``.
+You can also ask Nira to remember facts directly: say ``remember <key> is <value>`` and it will be stored in the database. Later, asking something like ``what is <key>?`` will retrieve the saved value before any other tools are used.
 
 ## Development
 

--- a/prompt.json
+++ b/prompt.json
@@ -4,5 +4,6 @@
   "researcher_system": "You research information and summarize findings.",
   "sysops_system": "You perform system administration and operational tasks.",
   "classify": "Classify the user request into one of: coder, researcher, sysops. Respond with only the label.\nRequest: {task}",
-  "planner": "You are a planner. Given the overall goal and last observation, return the next steps as a JSON list.\nGoal: {goal}\nObservation: {observation}"
+  "planner": "You are a planner. Given the overall goal and last observation, return the next steps as a JSON list.\nGoal: {goal}\nObservation: {observation}",
+  "memory": "If the user asks the assistant to remember information, respond with 'remember|<key>|<value>'. Otherwise respond with 'none'. Request: {task}"
 }

--- a/tests/test_memory_workflow.py
+++ b/tests/test_memory_workflow.py
@@ -7,13 +7,16 @@ from agent.agents.sysops_agent import SysOpsAgent
 from agent.agents.router_agent import RouterAgent
 
 
-def _make_agent(db_path):
-    classifier_llm = FakeListLLM(responses=["coder"])
+def _make_agent(db_path, memory_responses, classify_responses=None):
+    classify_responses = classify_responses or ["coder"]
+    classifier_llm = FakeListLLM(responses=classify_responses)
+    memory_llm = FakeListLLM(responses=memory_responses)
     coder_llm = FakeListLLM(responses=["code"])
     researcher_llm = FakeListLLM(responses=["research"])
     sysops_llm = FakeListLLM(responses=["sysops"])
     return RouterAgent(
         classifier_llm=classifier_llm,
+        memory_llm=memory_llm,
         coder=CoderAgent(llm=coder_llm),
         researcher=ResearcherAgent(llm=researcher_llm),
         sysops=SysOpsAgent(llm=sysops_llm),
@@ -23,7 +26,7 @@ def _make_agent(db_path):
 
 def test_remember_and_recall(tmp_path):
     db = tmp_path / "mem.db"
-    agent = _make_agent(db)
+    agent = _make_agent(db, ["remember|my favourite colour|blue", "none"])
     resp = agent.ask("remember my favourite colour is blue")
     assert "remembered" in resp.lower()
     result = agent.ask("what is my favourite colour?")
@@ -32,7 +35,7 @@ def test_remember_and_recall(tmp_path):
 
 def test_memory_hit_skips_classification(tmp_path):
     db = tmp_path / "mem.db"
-    agent = _make_agent(db)
+    agent = _make_agent(db, ["remember|api key|123", "none"])
     agent.ask("remember api key is 123")
     with patch.object(agent, "_classify", wraps=agent._classify) as mock_classify:
         answer = agent.ask("what is api key?")
@@ -42,7 +45,7 @@ def test_memory_hit_skips_classification(tmp_path):
 
 def test_memory_miss_uses_classification(tmp_path):
     db = tmp_path / "mem.db"
-    agent = _make_agent(db)
+    agent = _make_agent(db, ["none"], ["coder"])
     with patch.object(agent, "_classify", wraps=agent._classify) as mock_classify:
         agent.ask("some new task")
         mock_classify.assert_called_once()

--- a/tests/test_memory_workflow.py
+++ b/tests/test_memory_workflow.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+from langchain_community.llms import FakeListLLM
+
+from agent.agents.coder_agent import CoderAgent
+from agent.agents.researcher_agent import ResearcherAgent
+from agent.agents.sysops_agent import SysOpsAgent
+from agent.agents.router_agent import RouterAgent
+
+
+def _make_agent(db_path):
+    classifier_llm = FakeListLLM(responses=["coder"])
+    coder_llm = FakeListLLM(responses=["code"])
+    researcher_llm = FakeListLLM(responses=["research"])
+    sysops_llm = FakeListLLM(responses=["sysops"])
+    return RouterAgent(
+        classifier_llm=classifier_llm,
+        coder=CoderAgent(llm=coder_llm),
+        researcher=ResearcherAgent(llm=researcher_llm),
+        sysops=SysOpsAgent(llm=sysops_llm),
+        memory_db_path=db_path,
+    )
+
+
+def test_remember_and_recall(tmp_path):
+    db = tmp_path / "mem.db"
+    agent = _make_agent(db)
+    resp = agent.ask("remember my favourite colour is blue")
+    assert "remembered" in resp.lower()
+    result = agent.ask("what is my favourite colour?")
+    assert result == "blue"
+
+
+def test_memory_hit_skips_classification(tmp_path):
+    db = tmp_path / "mem.db"
+    agent = _make_agent(db)
+    agent.ask("remember api key is 123")
+    with patch.object(agent, "_classify", wraps=agent._classify) as mock_classify:
+        answer = agent.ask("what is api key?")
+        assert answer == "123"
+        mock_classify.assert_not_called()
+
+
+def test_memory_miss_uses_classification(tmp_path):
+    db = tmp_path / "mem.db"
+    agent = _make_agent(db)
+    with patch.object(agent, "_classify", wraps=agent._classify) as mock_classify:
+        agent.ask("some new task")
+        mock_classify.assert_called_once()

--- a/tests/test_planner_executor.py
+++ b/tests/test_planner_executor.py
@@ -14,12 +14,14 @@ class TestPlannerExecutor:
         planner_llm = FakeListLLM(responses=['["c","r","s"]', "[]"])
 
         classifier_llm = FakeListLLM(responses=["coder", "researcher", "sysops"])
+        memory_llm = FakeListLLM(responses=["none", "none", "none"])
         coder_llm = FakeListLLM(responses=["code-res"])
         researcher_llm = FakeListLLM(responses=["research-res"])
         sysops_llm = FakeListLLM(responses=["sysops-res"])
 
         router = RouterAgent(
             classifier_llm=classifier_llm,
+            memory_llm=memory_llm,
             coder=CoderAgent(llm=coder_llm),
             researcher=ResearcherAgent(llm=researcher_llm),
             sysops=SysOpsAgent(llm=sysops_llm),

--- a/tests/test_planner_executor.py
+++ b/tests/test_planner_executor.py
@@ -10,7 +10,7 @@ from agent.agents.sysops_agent import SysOpsAgent
 
 
 class TestPlannerExecutor:
-    def test_planner_delegates_to_router(self):
+    def test_planner_delegates_to_router(self, tmp_path):
         planner_llm = FakeListLLM(responses=['["c","r","s"]', "[]"])
 
         classifier_llm = FakeListLLM(responses=["coder", "researcher", "sysops"])
@@ -23,6 +23,7 @@ class TestPlannerExecutor:
             coder=CoderAgent(llm=coder_llm),
             researcher=ResearcherAgent(llm=researcher_llm),
             sysops=SysOpsAgent(llm=sysops_llm),
+            memory_db_path=tmp_path / "mem.db",
         )
 
         with patch("agent.agents.planner_executor.RouterAgent", return_value=router):

--- a/tests/test_routing_agent.py
+++ b/tests/test_routing_agent.py
@@ -9,7 +9,7 @@ from agent.agents.sysops_agent import SysOpsAgent
 
 
 class TestRoutingAgent:
-    def test_routing_to_specialists(self):
+    def test_routing_to_specialists(self, tmp_path):
         classifier_llm = FakeListLLM(responses=["coder", "researcher", "sysops"])
         coder_llm = FakeListLLM(responses=["code-result"])
         researcher_llm = FakeListLLM(responses=["research-result"])
@@ -20,13 +20,14 @@ class TestRoutingAgent:
             coder=CoderAgent(llm=coder_llm),
             researcher=ResearcherAgent(llm=researcher_llm),
             sysops=SysOpsAgent(llm=sysops_llm),
+            memory_db_path=tmp_path / "mem.db",
         )
 
         assert agent.ask("task1") == "code-result"
         assert agent.ask("task2") == "research-result"
         assert agent.ask("task3") == "sysops-result"
 
-    def test_load_prompt_only_called_on_init(self):
+    def test_load_prompt_only_called_on_init(self, tmp_path):
         with patch("agent.agents.router_agent.load_prompt") as mock_load:
             mock_load.return_value = {"classify": "label {task}"}
             classifier_llm = FakeListLLM(responses=["coder", "researcher"])
@@ -39,6 +40,7 @@ class TestRoutingAgent:
                 coder=CoderAgent(llm=coder_llm),
                 researcher=ResearcherAgent(llm=researcher_llm),
                 sysops=SysOpsAgent(llm=sysops_llm),
+                memory_db_path=tmp_path / "mem.db",
             )
 
             agent.ask("one")

--- a/tests/test_routing_agent.py
+++ b/tests/test_routing_agent.py
@@ -11,12 +11,14 @@ from agent.agents.sysops_agent import SysOpsAgent
 class TestRoutingAgent:
     def test_routing_to_specialists(self, tmp_path):
         classifier_llm = FakeListLLM(responses=["coder", "researcher", "sysops"])
+        memory_llm = FakeListLLM(responses=["none", "none", "none"])
         coder_llm = FakeListLLM(responses=["code-result"])
         researcher_llm = FakeListLLM(responses=["research-result"])
         sysops_llm = FakeListLLM(responses=["sysops-result"])
 
         agent = RouterAgent(
             classifier_llm=classifier_llm,
+            memory_llm=memory_llm,
             coder=CoderAgent(llm=coder_llm),
             researcher=ResearcherAgent(llm=researcher_llm),
             sysops=SysOpsAgent(llm=sysops_llm),
@@ -31,12 +33,14 @@ class TestRoutingAgent:
         with patch("agent.agents.router_agent.load_prompt") as mock_load:
             mock_load.return_value = {"classify": "label {task}"}
             classifier_llm = FakeListLLM(responses=["coder", "researcher"])
+            memory_llm = FakeListLLM(responses=["none", "none"])
             coder_llm = FakeListLLM(responses=["c1", "c2"])
             researcher_llm = FakeListLLM(responses=["r1"])
             sysops_llm = FakeListLLM(responses=["s1"])
 
             agent = RouterAgent(
                 classifier_llm=classifier_llm,
+                memory_llm=memory_llm,
                 coder=CoderAgent(llm=coder_llm),
                 researcher=ResearcherAgent(llm=researcher_llm),
                 sysops=SysOpsAgent(llm=sysops_llm),


### PR DESCRIPTION
## Summary
- persist and recall facts by intercepting `remember` commands and checking persistent memory before routing
- document how to remember and recall info
- test natural language memory behaviour and use temporary memory stores in routing and planner tests

## Testing
- `flake8 agent/agents/router_agent.py tests/test_memory_workflow.py tests/test_routing_agent.py tests/test_planner_executor.py`
- `pytest`