### PR TITLE
Retry user input until non-empty

### DIFF
--- a/console.py
+++ b/console.py
@@ -32,16 +32,22 @@ def typewriter(text: str, delay=0.015, prefix="") -> None:
 
 
 def get_user_input(use_voice: bool) -> str:
-    if use_voice:
-        if transcribe_whisper is None:
-            return ""
-        user_input = transcribe_whisper()
-        if not user_input:
+    while True:
+        if use_voice:
+            if transcribe_whisper is None:
+                return ""
+            try:
+                user_input = transcribe_whisper()
+            except KeyboardInterrupt:
+                raise
+            if user_input:
+                return user_input.strip()
             console.print("[yellow]Не удалось распознать речь. Попробуй ещё раз![/]")
-    else:
-        user_input = console.input(f"👤 [bold blue]{USERNAME}:[/] ")
-
-    return user_input.strip()
+        else:
+            user_input = console.input(f"👤 [bold blue]{USERNAME}:[/] ")
+            if user_input.strip():
+                return user_input.strip()
+            console.print("[yellow]Пустой ввод. Попробуй ещё раз![/]")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- Rework `get_user_input` to retry voice or text entry until non-empty
- Add prompts for retry when speech recognition or typed input fails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ebad4b8a8832286f3987f948eb2d4