### PR TITLE
Validate HTTP method in request_json

### DIFF
--- a/agent/tools/http_utils.py
+++ b/agent/tools/http_utils.py
@@ -16,10 +16,16 @@ def request_json(
 ) -> Any:
     """Helper for HTTP requests returning JSON.
 
-    Sends a request using ``requests`` with ``status_manager`` feedback and
-    handles errors. On success the response JSON is returned; on failure a
-    formatted error string is returned.
+    ``method`` must be one of ``{"get", "post", "put", "delete"}``. Sends a
+    request using ``requests`` with ``status_manager`` feedback and handles
+    errors. On success the response JSON is returned; on failure a formatted
+    error string is returned.
     """
+    allowed_methods = {"get", "post", "put", "delete"}
+    method = method.lower()
+    if method not in allowed_methods:
+        raise ValueError(f"Unsupported HTTP method: {method}")
+
     try:
         with status_manager.status(status_msg):
             response = getattr(requests, method)(url, timeout=timeout, **kwargs)

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from agent.tools.http_utils import request_json
 
 
@@ -26,3 +28,12 @@ class TestHttpUtils:
             error_msg="Fail",
         )
         assert "Fail" in result
+
+    def test_request_json_invalid_method(self):
+        with pytest.raises(ValueError, match="Unsupported HTTP method: patch"):
+            request_json(
+                "patch",
+                "http://example.com",
+                status_msg="getting",
+                error_msg="Fail",
+            )


### PR DESCRIPTION
## Summary
- validate allowed HTTP methods in `request_json`
- add tests for unsupported HTTP method

## Testing
- `pre-commit run --files agent/tools/http_utils.py tests/test_http_utils.py`
- `pytest tests/test_http_utils.py`