### PR TITLE
Materialize web search results

### DIFF
--- a/agent/tools/researcher/web_search_tool.py
+++ b/agent/tools/researcher/web_search_tool.py
@@ -18,7 +18,13 @@ def web_search_tool(query: str, max_results: int = 5) -> str:
     try:
         with status_manager.status("ищу в интернете"):
             with DDGS() as ddgs:
-                results = ddgs.text(query, safesearch="off", max_results=max_results)
+                results = list(
+                    ddgs.text(
+                        query,
+                        safesearch="off",
+                        max_results=max_results,
+                    )
+                )
     except Exception as e:
         return f"Search failed: {e}"
 

--- a/tests/test_web_search_tool.py
+++ b/tests/test_web_search_tool.py
@@ -3,13 +3,33 @@ from unittest.mock import patch
 from agent.tools.researcher.web_search_tool import web_search_tool
 
 
+class FakeDDGS:
+    last_instance = None
+
+    def __enter__(self):
+        FakeDDGS.last_instance = self
+        self.closed = False
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.closed = True
+
+    def text(self, query, safesearch="off", max_results=5):
+        self.last_call = (query, safesearch, max_results)
+
+        def generator():
+            if self.closed:
+                raise RuntimeError("DDGS instance is closed")
+            yield {"title": "Example", "href": "https://example.com", "body": "Test"}
+
+        return generator()
+
+
 class TestWebSearchTool:
-    @patch("agent.tools.researcher.web_search_tool.DDGS.text")
-    def test_web_search(self, mock_text):
-        mock_text.return_value = [
-            {"title": "Example", "href": "https://example.com", "body": "Test"}
-        ]
+    @patch("agent.tools.researcher.web_search_tool.DDGS", FakeDDGS)
+    def test_web_search(self):
         result = web_search_tool.func("example", max_results=1)
         assert "Example" in result
         assert "https://example.com" in result
-        mock_text.assert_called_once_with("example", safesearch="off", max_results=1)
+        assert FakeDDGS.last_instance.last_call == ("example", "off", 1)
+        assert FakeDDGS.last_instance.closed is True


### PR DESCRIPTION
## Summary
- Avoid iterating DDGS search generator after the context closes by materializing results inside the context.
- Add regression test ensuring results are still available after leaving the DDGS context.

## Testing
- `pytest tests/test_web_search_tool.py`