### PR TITLE
Skip planner execution on empty input

### DIFF
--- a/console.py
+++ b/console.py
@@ -84,6 +84,9 @@ def main() -> None:
         while True:
             user_input = get_user_input(use_voice)
 
+            if not user_input:
+                continue
+
             if user_input in ["/exit", "выход", "exit"]:
                 console.print("[bold magenta]👾 Nira:[/] До встречи!")
                 break


### PR DESCRIPTION
## Summary
- skip planner when speech recognition returns empty text
- keep warning shown to user when recognition fails

## Testing
- `pytest`